### PR TITLE
Simplify implementation of example function in introduction.clj

### DIFF
--- a/examples/introduction.clj
+++ b/examples/introduction.clj
@@ -332,14 +332,11 @@
 
 (def foo
   (gen [prob-a]
-    (let [val (atom true)]
-      (when (gen/trace :a (dist/bernoulli prob-a))
-        (swap! val #(and (gen/trace :b (dist/bernoulli 0.6))
-                         %)))
-      (let [prob-c (if @val 0.9 0.2)]
-        (swap! val #(and (gen/trace :c (dist/bernoulli prob-c))
-                         %)))
-      @val)))
+    (let [a-b (or (not (gen/trace :a (dist/bernoulli prob-a)))
+                  (gen/trace :b (dist/bernoulli 0.6)))
+          prob-c (if a-b 0.9 0.2)]
+      (and (gen/trace :c (dist/bernoulli prob-c))
+           a-b))))
 
 (trace/choices (gf/simulate foo [0.3]))
 


### PR DESCRIPTION
## What does this do?

- Refactors the `foo` function in `introduction.clj` to get rid of the stateful assignment.

## Why should we do this

- Improved comprehensibility for people going through the tutorial.