### PR TITLE
Update build, developer docs to allow for static site generation

### DIFF
--- a/.clj-kondo/config.edn
+++ b/.clj-kondo/config.edn
@@ -1,0 +1,1 @@
+{:config-paths ["../resources/clj-kondo.exports/io.github.inferenceql/gen.clj"]}

--- a/.github/workflows/linter.yaml
+++ b/.github/workflows/linter.yaml
@@ -1,13 +1,18 @@
-name: linter
-on: push
+name: Linter
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
 jobs:
   lint-files:
     runs-on: ubuntu-latest
     steps:
       - name: Setup clj-kondo
-        uses: DeLaGuardo/setup-clj-kondo@master
+        uses: DeLaGuardo/setup-clojure@master
         with:
-          version: '2022.04.25'
+          bb: latest
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -18,5 +23,8 @@ jobs:
           path: .clj-kondo/.cache
           key: clj-kondo-cache-${{ hashFiles('deps.edn') }}
 
+      - name: Lint dependencies
+        run: bb lint-deps
+
       - name: Lint files
-        run: clj-kondo --lint src test --dependencies --config .clj-kondo/ci-config.edn
+        run: bb lint --config '{:output {:pattern "::{{level}} file={{filename}},line={{row}},col={{col}}::{{message}}"}}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release to Clojars
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    environment: Clojars Release
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: latest
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 17
+
+      - name: Cache m2
+        uses: actions/cache@v2
+        with:
+          path: ~/.m2
+          key: m2-${{ hashFiles('deps.edn') }}
+
+      - name: Cache gitlibs
+        uses: actions/cache@v2
+        with:
+          path: ~/.gitlibs
+          key: gitlibs-${{ hashFiles('deps.edn') }}
+
+      - name: Install dependencies
+        run: clojure -P -M:build
+
+      - name: Release
+        run: clojure -T:build publish
+        env:
+          CLOJARS_USERNAME: ${{ secrets.CLOJARS_USERNAME }}
+          CLOJARS_PASSWORD: ${{ secrets.CLOJARS_PASSWORD }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,5 +1,10 @@
 name: tests
-on: push
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
 jobs:
   run-tests:
     runs-on: ubuntu-latest
@@ -14,6 +19,7 @@ jobs:
         uses: DeLaGuardo/setup-clojure@master
         with:
           cli: 1.10.3.1040
+          bb: latest
 
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -31,7 +37,7 @@ jobs:
           key: gitlibs-${{ hashFiles('deps.edn') }}
 
       - name: Prepare dependencies
-        run: clojure -P -M:test:clj-test
+        run: clojure -P -M:test:runner
 
       - name: Run Clojure tests
-        run: clojure -X:test:clj-test
+        run: bb test:clj

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 *.class
 *.jar
+.clj-kondo/.lock
+.clj-kondo/inline-configs
+.clj-kondo/.cache
+public/
 .clerk/
 .cpcache/
 .lein-deps-sum
@@ -13,3 +17,4 @@
 /target/
 pom.xml
 pom.xml.asc
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ public/
 /lib/
 /target/
 pom.xml
+!template/pom.xml
 pom.xml.asc
 node_modules

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,0 +1,81 @@
+## Dev Dependencies
+
+- [node.js](https://nodejs.org/en/)
+- The [clojure command line tool](https://clojure.org/guides/install_clojure)
+- [Babashka](https://github.com/babashka/babashka#installation)
+
+## Github Pages, Docs Notebook
+
+The project's [Github Pages site](https://inferenceql.github.io/gen.clj) hosts
+an interactive [Clerk](https://github.com/nextjournal/clerk) notebook
+demonstrating the library's use.
+
+### Local Notebook Dev
+
+Start a Clojure process however you like, and run `(user/serve!)` to run the
+Clerk server. This command should open up `localhost:7777`.
+
+Alternatively, run
+
+```sh
+bb clerk-watch
+```
+
+### Static Build
+
+To test the static build locally:
+
+```
+bb publish-local
+```
+
+This will generate the static site in `public/build`, start a development http
+server and open up a browser window (http://127.0.0.1:8080/) with the production
+build of the documentation notebook.
+
+### GitHub Pages
+
+To build and release to Github Pages:
+
+```
+bb release-gh-pages
+```
+
+This will ship the site to https://inferenceql.github.io/gen.clj.
+
+## Publishing to Clojars
+
+The template for the project's `pom.xml` lives at
+[`template/pom.xml`](https://github.com/InferenceQL/gen.clj/blob/main/template/pom.xml).
+
+To create a new release:
+
+- Update the version in
+  [build.clj](https://github.com/InferenceQL/gen.clj/blob/main/build.clj)
+- Make a new [Github
+  Release](https://github.com/InferenceQL/gen.clj/releases) with tag
+  `v<the-new-version>`.
+
+Submitting the release will create the new tag and trigger the following
+command:
+
+```
+bb release
+```
+
+The new release will appear on Clojars.
+
+## Linting
+
+Code is linted with [`clj-kondo`](https://github.com/clj-kondo/clj-kondo):
+
+```
+bb lint
+```
+
+The first time you interact with the project, run the following command to lint
+all dependencies and populate the `clj-kondo` cache:
+
+```
+bb lint-deps
+```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -1,16 +1,16 @@
-## Dev Dependencies
+## Dev dependencies
 
 - [node.js](https://nodejs.org/en/)
 - The [clojure command line tool](https://clojure.org/guides/install_clojure)
 - [Babashka](https://github.com/babashka/babashka#installation)
 
-## Github Pages, Docs Notebook
+## Github Pages, docs notebook
 
 The project's [Github Pages site](https://inferenceql.github.io/gen.clj) hosts
 an interactive [Clerk](https://github.com/nextjournal/clerk) notebook
 demonstrating the library's use.
 
-### Local Notebook Dev
+### Local notebook dev
 
 Start a Clojure process however you like, and run `(user/serve!)` to run the
 Clerk server. This command should open up `localhost:7777`.
@@ -21,7 +21,7 @@ Alternatively, run
 bb clerk-watch
 ```
 
-### Static Build
+### Static build
 
 To test the static build locally:
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,11 @@
 An open-source stack for generative modeling and probabilistic inference.
 
 > **Warning**
->
-> Gen.clj, the Clojure implementation of the Gen language, currently only supports a subset of Gen's features. For a complete implementation see [Gen.jl](https://github.com/probcomp/Gen.jl). If you would like to get involved with Gen.clj's development please [contact us](mailto:contributing@zane.io).
+> Gen.clj, the Clojure implementation of the Gen language, currently only
+> supports a subset of Gen's features. For a complete implementation see
+> [Gen.jl](https://github.com/probcomp/Gen.jl). If you would like to get
+> involved with Gen.clj's development please [contact
+> us](mailto:contributing@zane.io).
 
 ## Why Gen?
 
@@ -22,7 +25,10 @@ An open-source stack for generative modeling and probabilistic inference.
 
 ### Install
 
-Gen.clj is currently only available as a [git dependency](https://clojure.org/guides/deps_and_cli#_using_git_libraries). To install Gen.clj, add the following entry to your `deps.edn` under the `:deps` key:
+Gen.clj is currently only available as a [git
+dependency](https://clojure.org/guides/deps_and_cli#_using_git_libraries). To
+install Gen.clj, add the following entry to your `deps.edn` under the `:deps`
+key:
 
 ``` clojure
 io.github.inferenceql/gen.clj {:git/url "https://github.com/inferenceql/gen.clj"
@@ -31,37 +37,66 @@ io.github.inferenceql/gen.clj {:git/url "https://github.com/inferenceql/gen.clj"
 
 ### Learn
 
-There are tutorials available as [Clerk](https://github.com/nextjournal/clerk/) notebooks in the `examples` directory. 
+The project's [interactive documentation][emmy-viewers-url] was generated from
+the notebooks in the
+[`examples`](https://github.com/InferenceQL/gen.clj/tree/main/examples)
+directory using Nextjournal's [Clerk][clerk-url]. If you'd like to edit or play
+with the documentation or demos, you'll need to install
 
-To view a notebook first clone this repository, then start a Clojure REPL that includes Clerk:
+- The [Clojure command line tool](https://clojure.org/guides/install_clojure)
+- [Babashka](https://github.com/babashka/babashka#installation)
 
-``` shell
-clj -A:clerk
+Next, clone the repository:
+
+```bash
+git clone git@github.com:InferenceQL/gen.clj.git
+cd gen.clj
 ```
 
-Require and start Clerk:
+Run this command in the cloned repository:
 
-``` clojure
-(require '[nextjournal.clerk :as clerk])
-(clerk/serve! {:browse true})
+```sh
+bb clerk-watch
 ```
 
-This will open a tab in your web browser. You can then view a notebook in that tab:
+This will open a browser window to `http://localhost:7777` with the contents of
+the ["Introduction to Modeling in
+Gen.clj"](https://github.com/InferenceQL/gen.clj/blob/main/examples/intro_to_modeling.clj)
+notebook loaded. Any edits you make to `examples/intro_to_modeling.clj` on your
+filesystem will update this page, and editing any other file in `examples`, like
+`examples/introduction.clj`, will load that file's namespace into the browser.
 
-``` clojure
-(clerk/show! "examples/intro_to_modeling.clj")
-```
-
-For more information on Clerk see the [Book of Clerk](https://book.clerk.vision/) and the [Clerk repository](https://github.com/nextjournal/clerk).
+For more information on Clerk see the [Book of
+Clerk](https://book.clerk.vision/) and the [Clerk
+repository](https://github.com/nextjournal/clerk).
 
 ## Contributors
 
 ### The Gen team
 
-Gen.jl was created by [Marco Cusumano-Towner](https://www.mct.dev/) the [MIT Probabilistic Computing Project](http://probcomp.csail.mit.edu/), which is led by [Vikash Mansinghka](http://probcomp.csail.mit.edu/principal-investigator/). Gen.jl has grown and is maintained through the help of a core research and engineering team that includes [Alex Lew](http://alexlew.net/), [Tan Zhi-Xuan](https://github.com/ztangent/), [George Matheos](https://www.linkedin.com/in/george-matheos-429982160/), [McCoy Becker](https://femtomc.github.io/), and [Feras Saad](http://fsaad.mit.edu/), as well as a number of open-source contributors. Gen.jl was adapted to Clojure by [Zane Shelby](https://zane.io) with help from Ulrich Schaechtle. The Gen architecture is described in [Marco's PhD thesis](https://www.mct.dev/assets/mct-thesis.pdf).
+Gen.jl was created by [Marco Cusumano-Towner](https://www.mct.dev/) the [MIT
+Probabilistic Computing Project](http://probcomp.csail.mit.edu/), which is led
+by [Vikash Mansinghka](http://probcomp.csail.mit.edu/principal-investigator/).
+Gen.jl has grown and is maintained through the help of a core research and
+engineering team that includes [Alex Lew](http://alexlew.net/), [Tan
+Zhi-Xuan](https://github.com/ztangent/), [George
+Matheos](https://www.linkedin.com/in/george-matheos-429982160/), [McCoy
+Becker](https://femtomc.github.io/), and [Feras Saad](http://fsaad.mit.edu/), as
+well as a number of open-source contributors. Gen.jl was adapted to Clojure by
+[Zane Shelby](https://zane.io) with help from Ulrich Schaechtle. The Gen
+architecture is described in [Marco's PhD
+thesis](https://www.mct.dev/assets/mct-thesis.pdf).
 
 ### Citation
 
 If you use Gen in your research, please cite our PLDI paper:
 
-> Gen: A General-Purpose Probabilistic Programming System with Programmable Inference. Cusumano-Towner, M. F.; Saad, F. A.; Lew, A.; and Mansinghka, V. K. In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language Design and Implementation (PLDI ‘19). ([pdf](https://dl.acm.org/doi/10.1145/3314221.3314642)) ([bibtex](https://www.gen.dev/assets/gen-pldi.txt))
+> Gen: A General-Purpose Probabilistic Programming System with Programmable
+> Inference. Cusumano-Towner, M. F.; Saad, F. A.; Lew, A.; and Mansinghka, V. K.
+> In Proceedings of the 40th ACM SIGPLAN Conference on Programming Language
+> Design and Implementation (PLDI ‘19).
+> ([pdf](https://dl.acm.org/doi/10.1145/3314221.3314642))
+> ([bibtex](https://www.gen.dev/assets/gen-pldi.txt))
+
+
+[clerk-url]: https://github.com/nextjournal/clerk

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,69 @@
+{:deps {org.babashka/http-server {:mvn/version "0.1.11"}
+        org.babashka/cli {:mvn/version "0.2.23"}
+        io.github.clj-kondo/clj-kondo-bb
+        {:git/tag "v2023.01.20" :git/sha "adfc7df"}}
+ :tasks
+ {:requires ([babashka.cli :as cli])
+  :init
+  (do (def cli-opts
+        (cli/parse-opts *command-line-args* {:coerce {:port :int}}))
+
+      (defn X [cmd]
+        (let [args *command-line-args*]
+          (if (even? (count args))
+            (apply shell cmd args)
+            (do (println "Please supply an even number of arguments!")
+                (System/exit 1))))))
+
+  clerk-watch
+  {:doc "Runs `user/serve!` with a watcher process generating custom JS."
+   :task (X "clojure -X:nextjournal/clerk user/serve!")}
+
+  test:clj
+  {:doc "Run CLJ tests."
+   :task (shell "clojure -X:test:runner")}
+
+  build-static
+  {:doc "Generate a fresh static build."
+   :task
+   (apply shell
+          "clojure -X:nextjournal/clerk"
+          *command-line-args*)}
+
+  serve
+  {:doc "Serve static assets"
+   :requires ([babashka.http-server :as server])
+   :task (server/exec
+          (merge {:port 8080
+                  :dir "public/build"}
+                 cli-opts))}
+
+  release-gh-pages
+  {:doc "Generate a fresh static build and release it to Github Pages."
+   :task
+   (do (shell "rm -rf public/build")
+       (run 'build-static)
+       (shell "npm run gh-pages"))}
+
+  publish-local
+  {:doc "Generate a fresh static build and start a local webserver."
+   :task
+   (do (run 'build-static)
+       (run 'serve))}
+
+  release
+  {:doc "Release the library to Clojars."
+   :task (shell "clojure -T:build publish")}
+
+  lint-deps
+  {:requires ([clj-kondo.core :as kondo])
+   :doc "Lint dependencies."
+   :task (kondo/run!
+          {:lint [(with-out-str
+                    (babashka.tasks/clojure "-Spath -A:nextjournal/clerk"))]
+           :dependencies true})}
+
+  lint
+  {:doc "Lint source-containing directories with clj-kondo."
+   :task (exec 'clj-kondo.core/exec)
+   :exec-args {:lint ["src" "dev" "test" "examples"]}}}}

--- a/build.clj
+++ b/build.clj
@@ -1,0 +1,90 @@
+(ns build
+  "tools.build declarations for the gen.clj library."
+  (:require [clojure.tools.build.api :as b]))
+
+;; ## Variables
+
+(def lib 'io.github.inferenceql/gen.clj)
+(def version "0.1.0")
+
+(defn- ->version
+  ([] version)
+  ([suffix]
+   (if suffix
+     (format "%s-%s" version suffix)
+     version)))
+
+;; source for jar creation.
+(def class-dir "target/classes")
+(def basis
+  (b/create-basis
+   {:project "deps.edn"}))
+
+(defn ->jar-file [version]
+  (format "target/%s-%s.jar" (name lib) version))
+
+;; ## Tasks
+
+(defn clean [opts]
+  (println "\nCleaning target...")
+  (b/delete {:path "target"})
+  opts)
+
+(defn jar
+  "Builds a jar containing all library code and
+
+  Optionally supply a string via `:version-suffix` to append `-<suffix>` to the
+  generated version."
+  [{:keys [version-suffix] :as opts}]
+  (let [version  (->version version-suffix)
+        jar-file (->jar-file version)]
+    (b/write-pom {:class-dir class-dir
+                  :lib lib
+                  :version version
+                  :scm
+                  {:tag (str "v" version)
+                   :connection "scm:git:git://github.com/InferenceQL/gen.clj.git"
+                   :developConnection "scm:git:ssh://git@github.com/InferenceQL/gen.clj.git"
+                   :url "https://github.com/InferenceQL/gen.clj"}
+                  :basis basis
+                  :src-pom "template/pom.xml"
+                  :src-dirs ["src"]})
+    (doseq [f ["README.md" "LICENSE" "deps.edn"]]
+      (b/copy-file {:src f :target (format "%s/%s" class-dir f)}))
+    (b/copy-dir {:src-dirs ["src"]
+                 :target-dir class-dir})
+    (b/jar {:class-dir class-dir
+            :jar-file jar-file})
+    (println (str "Created " jar-file "."))
+    (assoc opts
+           :jar-file jar-file
+           :built-jar-version version)))
+
+(defn install
+  "Clean, generate a jar and install the jar into the local Maven repository."
+  [opts]
+  (clean opts)
+  (let [{:keys [built-jar-version jar-file]} (jar opts)]
+    (b/install {:class-dir class-dir
+                :lib lib
+                :version built-jar-version
+                :basis basis
+                :jar-file jar-file})
+    (println (str "Installed " jar-file " to local Maven repository."))
+    opts))
+
+(defn publish
+  "Generates a jar with all project sources and resources and publishes it to
+  Clojars."
+  [opts]
+  (clean opts)
+  (let [{:keys [jar-file]} (jar opts)]
+    (println (str "Publishing " jar-file " to Clojars!"))
+    ((requiring-resolve 'deps-deploy.deps-deploy/deploy)
+     (merge {:installer :remote
+             :sign-releases? false
+             :artifact jar-file
+             :pom-file (b/pom-path {:lib lib :class-dir class-dir})}
+            opts))
+    (println "Published.")
+    opts))

--- a/deps.edn
+++ b/deps.edn
@@ -1,10 +1,33 @@
-{:deps {generateme/fastmath {:mvn/version "2.1.9-SNAPSHOT"}
-        org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
-        org.clojure/clojure {:mvn/version "1.11.1"}}
+{:paths ["src" "resources"]
 
- :aliases {:clerk {:extra-deps {io.github.nextjournal/clerk {:mvn/version "0.13.842"}}
-                   :extra-paths ["examples" "examples/src"]}
-           :test {:extra-paths ["test"]}
-           :clj-test {:extra-deps {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
-                      :main-opts ["-m" "cognitect.test-runner"]
-                      :exec-fn cognitect.test-runner.api/test}}}
+ :deps
+ {generateme/fastmath {:mvn/version "2.1.9-SNAPSHOT"}
+  org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
+  org.clojure/clojure {:mvn/version "1.11.1"}}
+
+ :aliases
+ {:nextjournal/clerk
+  {:extra-paths ["dev" "examples" "examples/src"]
+   :extra-deps {io.github.nextjournal/clerk
+                #_{:mvn/version "0.14.919"}
+                {:git/sha "fc6df7186bfea2571fff2dd790d0ad63f8d6295f"}
+                }
+   :exec-fn user/build!}
+
+  :test
+  {:extra-paths ["test"]}
+
+  ;; See https://github.com/cognitect-labs/test-runner for invocation
+  ;; instructions, or call `clojure -X:test:runner`.
+  :runner
+  {:extra-deps
+   {io.github.cognitect-labs/test-runner {:git/tag "v0.5.1" :git/sha "dfb30dd"}}
+   :main-opts ["-m" "cognitect.test-runner"]
+   :exec-fn cognitect.test-runner.api/test
+   :exec-args ["test"]}
+
+  :build
+  {:deps
+   {io.github.clojure/tools.build {:git/tag "v0.9.4" :git/sha "76b78fe"}
+    slipset/deps-deploy {:mvn/version "0.2.0"}}
+   :ns-default build}}}

--- a/deps.edn
+++ b/deps.edn
@@ -8,10 +8,7 @@
  :aliases
  {:nextjournal/clerk
   {:extra-paths ["dev" "examples" "examples/src"]
-   :extra-deps {io.github.nextjournal/clerk
-                #_{:mvn/version "0.14.919"}
-                {:git/sha "fc6df7186bfea2571fff2dd790d0ad63f8d6295f"}
-                }
+   :extra-deps {io.github.nextjournal/clerk {:mvn/version "0.14.919"}}
    :exec-fn user/build!}
 
   :test

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -2,7 +2,7 @@
   (:require [nextjournal.clerk :as clerk]))
 
 (def index
-  "examples/introduction.clj")
+  "examples/intro_to_modeling.clj")
 
 (def notebooks
   ["examples/introduction.clj"

--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,39 @@
+(ns user
+  (:require [nextjournal.clerk :as clerk]))
+
+(def index
+  "examples/introduction.clj")
+
+(def notebooks
+  ["examples/introduction.clj"
+   "examples/intro_to_modeling.clj"])
+
+(def defaults
+  {:index index})
+
+(def serve-defaults
+  (assoc defaults
+         :browse? true
+         :watch-paths ["examples"]))
+
+(def static-defaults
+  (assoc defaults
+         :browse? false
+         :paths notebooks
+         :git/url "https://github.com/InferenceQL/gen.clj"))
+
+(defn serve!
+  ([] (serve! {}))
+  ([opts]
+   (let [{:keys [browse? index] :as opts} (merge serve-defaults opts)]
+     (when (and browse? index)
+       (clerk/show! index))
+     (clerk/serve! opts))))
+
+(def halt! clerk/halt!)
+
+(defn build!
+  ([] (build! {}))
+  ([opts]
+   (clerk/build!
+    (merge static-defaults opts))))

--- a/examples/intro_to_modeling.clj
+++ b/examples/intro_to_modeling.clj
@@ -1,9 +1,14 @@
-^{:nextjournal.clerk/toc true
-  :nextjournal.clerk/visibility {:code :hide :result :hide}}
+^{:nextjournal.clerk/visibility {:code :hide :result :hide}}
 (ns intro-to-modeling
-  (:require [gen.choice-map]
+  {:nextjournal.clerk/toc true}
+  (:require [gen]
+            [gen.choice-map]
+            [gen.dynamic :refer [gen]]
             [gen.clerk.callout :as callout]
             [gen.clerk.viewer :as viewer]
+            [gen.distribution.apache-commons-math3 :as math3]
+            [gen.distribution.fastmath :as fastmath]
+            [gen.generative-function :as gf]
             [nextjournal.clerk :as clerk]))
 
 ;; # Tutorial: Introduction to modeling in Gen.clj
@@ -81,10 +86,11 @@
 
 ;; Gen is a library for the Clojure programming language. The library can be
 ;; required with:
-
-^{::clerk/visibility {:result :hide}}
-(require '[gen]
-         '[gen.dynamic :refer [gen]])
+;;
+;; ```clojure
+;; (require '[gen]
+;;          '[gen.dynamic :refer [gen]])
+;; ```
 
 ;; Gen programs typically consist of a combination of (i) probabilistic models
 ;; written in modeling languages and (ii) inference programs written in regular
@@ -160,8 +166,10 @@
 ;; A simple example of such an invocation is a normal distribution parametrized
 ;; with mean 0 and standard deviation 1:
 
-(require '[gen.distribution.fastmath :as fastmath]
-         '[gen.distribution.apache-commons-math3 :as math3])
+;; ```clojure
+;; (require '[gen.distribution.fastmath :as fastmath]
+;;          '[gen.distribution.apache-commons-math3 :as math3])
+;; ```
 
 (def my-variable (gen/trace :my-variable-address (fastmath/normal 0 1)))
 
@@ -275,9 +283,10 @@
 ;; generative function and obtain its trace using the [`
 ;; simulate`](https://probcomp.github.io/Gen/dev/ref/gfi/#Gen.simulate) method
 ;; from the Gen API:
-
-^{::clerk/visibility {:result :hide}}
-(require '[gen.generative-function :as gf])
+;;
+;; ```clojure
+;; (require '[gen.generative-function :as gf])
+;; ```
 
 (def trace (gf/simulate line-model [xs]))
 

--- a/examples/introduction.clj
+++ b/examples/introduction.clj
@@ -1,8 +1,9 @@
-^:nextjournal.clerk/toc
 (ns introduction
+  {:nextjournal.clerk/toc true}
   (:require [clojure.math :as math]
             [clojure.repl :as repl]
             [gen]
+            [gen.distribution.apache-commons-math3]
             [gen.distribution.fastmath :as dist]
             [gen.generative-function :as gf]
             [gen.trace :as trace]
@@ -37,7 +38,9 @@
 ^{::clerk/visibility {:code :hide :result :hide}}
 (defmacro doc
   [sym]
-  `(clerk/html [:pre (with-out-str (repl/doc ~sym))]))
+  `(clerk/html
+    {::clerk/width :wide}
+    [:pre (with-out-str (repl/doc ~sym))]))
 
 (doc dist/uniform-discrete)
 (doc dist/bernoulli)
@@ -49,13 +52,13 @@
 ;; The function `f` first binds the value of `n0` to a random value drawn from
 ;; the set of integers `#{1 ... 10}`:
 
-;; ```
+;; ```clojure
 ;; (dist/uniform-discrete 1 10)
 ;; ```
 
 ;; Then, with probability `p`, it multiplies n by two:
 ;;
-;; ```
+;; ```clojure
 ;; (if (dist/bernoulli p)
 ;;   (* n0 2)
 ;;   n0)
@@ -65,7 +68,7 @@
 ;; the integer is `n`, and with probability `0.5` it is uniformly chosen from
 ;; the remaining `19` integers. It returns this sampled integer:
 
-;; ```
+;; ```clojure
 ;; (dist/categorical (for [i (range 1 21)]
 ;;                      (if (= i n1)
 ;;                        0.5

--- a/examples/introduction.clj
+++ b/examples/introduction.clj
@@ -3,6 +3,12 @@
   (:require [clojure.math :as math]
             [clojure.repl :as repl]
             [gen]
+            ;; NOTE: these distributions aren't used explicitly in this file,
+            ;; but not including this causes the static build of
+            ;; `intro_to_modeling.clj` to crash. There is some lurking bug in
+            ;; Clerk's usage of `clojure.tools.analyzer` related to [this
+            ;; PR](https://github.com/nextjournal/clerk/pull/386). Please leave
+            ;; this in until the static build passes without it!
             [gen.distribution.apache-commons-math3]
             [gen.distribution.fastmath :as dist]
             [gen.generative-function :as gf]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,813 @@
+{
+  "name": "gen.clj",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "devDependencies": {
+        "gh-pages": "^3.2.3"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "node_modules/email-addresses": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
+      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
+      "dev": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "dependencies": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "dependencies": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/avajs/find-cache-dir?sponsor=1"
+      }
+    },
+    "node_modules/find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=6 <7 || >=8"
+      }
+    },
+    "node_modules/fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "node_modules/gh-pages": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
+      "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.1",
+        "commander": "^2.18.0",
+        "email-addresses": "^3.0.1",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^8.1.0",
+        "globby": "^6.1.0"
+      },
+      "bin": {
+        "gh-pages": "bin/gh-pages.js",
+        "gh-pages-clean": "bin/gh-pages-clean.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "dependencies": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      },
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "node_modules/inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "dependencies": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "dependencies": {
+        "p-try": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "dependencies": {
+        "pinkie": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  },
+  "dependencies": {
+    "array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "dev": true,
+      "requires": {
+        "array-uniq": "^1.0.1"
+      }
+    },
+    "array-uniq": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+      "integrity": "sha512-MNha4BWQ6JbwhFhj03YK552f7cb3AzoE8SzeljgChvL1dl3IcvggXVz1DilzySZkCja+CXuZbdW7yATchWn8/Q==",
+      "dev": true
+    },
+    "async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "commondir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
+      "integrity": "sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
+    },
+    "email-addresses": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/email-addresses/-/email-addresses-3.1.0.tgz",
+      "integrity": "sha512-k0/r7GrWVL32kZlGwfPNgB2Y/mMXVTq/decgLczm/j34whdaspNrZO8CnXPf1laaHxI6ptUlsnAxN+UAPw+fzg==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "dev": true
+    },
+    "filename-reserved-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/filename-reserved-regex/-/filename-reserved-regex-2.0.0.tgz",
+      "integrity": "sha512-lc1bnsSr4L4Bdif8Xb/qrtokGbq5zlsms/CYH8PP+WtCkGNF65DPiQY8vG3SakEdRn8Dlnm+gW/qWKKjS5sZzQ==",
+      "dev": true
+    },
+    "filenamify": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/filenamify/-/filenamify-4.3.0.tgz",
+      "integrity": "sha512-hcFKyUG57yWGAzu1CMt/dPzYZuv+jAJUT85bL8mrXvNe6hWj6yEHEc4EdcgiA6Z3oi1/9wXJdZPXF2dZNgwgOg==",
+      "dev": true,
+      "requires": {
+        "filename-reserved-regex": "^2.0.0",
+        "strip-outer": "^1.0.1",
+        "trim-repeated": "^1.0.0"
+      }
+    },
+    "find-cache-dir": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.2.tgz",
+      "integrity": "sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==",
+      "dev": true,
+      "requires": {
+        "commondir": "^1.0.1",
+        "make-dir": "^3.0.2",
+        "pkg-dir": "^4.1.0"
+      }
+    },
+    "find-up": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+      "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+      "dev": true,
+      "requires": {
+        "locate-path": "^5.0.0",
+        "path-exists": "^4.0.0"
+      }
+    },
+    "fs-extra": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+      "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^4.0.0",
+        "universalify": "^0.1.0"
+      }
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
+      "dev": true
+    },
+    "gh-pages": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/gh-pages/-/gh-pages-3.2.3.tgz",
+      "integrity": "sha512-jA1PbapQ1jqzacECfjUaO9gV8uBgU6XNMV0oXLtfCX3haGLe5Atq8BxlrADhbD6/UdG9j6tZLWAkAybndOXTJg==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.1",
+        "commander": "^2.18.0",
+        "email-addresses": "^3.0.1",
+        "filenamify": "^4.3.0",
+        "find-cache-dir": "^3.3.1",
+        "fs-extra": "^8.1.0",
+        "globby": "^6.1.0"
+      }
+    },
+    "glob": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
+      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.1.1",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globby": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
+      "integrity": "sha512-KVbFv2TQtbzCoxAnfD6JcHZTYCzyliEaaeM/gH8qQdkKr5s0OP9scEgvdcngyk7AVdY6YVW/TJHd+lQ/Df3Daw==",
+      "dev": true,
+      "requires": {
+        "array-union": "^1.0.1",
+        "glob": "^7.0.3",
+        "object-assign": "^4.0.1",
+        "pify": "^2.0.0",
+        "pinkie-promise": "^2.0.0"
+      }
+    },
+    "graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "jsonfile": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+      "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
+    "locate-path": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+      "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+      "dev": true,
+      "requires": {
+        "p-locate": "^4.1.0"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
+    "make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "dev": true,
+      "requires": {
+        "semver": "^6.0.0"
+      }
+    },
+    "minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "p-limit": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+      "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+      "dev": true,
+      "requires": {
+        "p-try": "^2.0.0"
+      }
+    },
+    "p-locate": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+      "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+      "dev": true,
+      "requires": {
+        "p-limit": "^2.2.0"
+      }
+    },
+    "p-try": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
+      "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
+      "dev": true
+    },
+    "pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "dev": true
+    },
+    "pinkie": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha512-MnUuEycAemtSaeFSjXKW/aroV7akBbY+Sv+RkyqFjgAe73F+MR0TBWKBRDkmfWq/HiFmdavfZ1G7h4SPZXaCSg==",
+      "dev": true
+    },
+    "pinkie-promise": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha512-0Gni6D4UcLTbv9c57DfxDGdr41XfgUjqWZu492f0cIGr16zDU06BWP/RAEvOuo7CQ0CNjHaLlM59YJJFm3NWlw==",
+      "dev": true,
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
+    },
+    "pkg-dir": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+      "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.0.0"
+      }
+    },
+    "semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true
+    },
+    "strip-outer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/strip-outer/-/strip-outer-1.0.1.tgz",
+      "integrity": "sha512-k55yxKHwaXnpYGsOzg4Vl8+tDrWylxDEpknGjhTiZB8dFRU5rTo9CAzeycivxV3s+zlTKwrs6WxMxR95n26kwg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "trim-repeated": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/trim-repeated/-/trim-repeated-1.0.0.tgz",
+      "integrity": "sha512-pkonvlKk8/ZuR0D5tLW8ljt5I8kmxp2XKymhepUeOdCEfKpZaktSArkLHZt76OB1ZvO9bssUsDty4SWhLvZpLg==",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.2"
+      }
+    },
+    "universalify": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "dev": true
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "devDependencies": {
+    "gh-pages": "^3.2.3"
+  },
+  "scripts": {
+    "gh-pages": "gh-pages -d public/build --dotfiles true"
+  }
+}

--- a/resources/clj-kondo.exports/io.github.inferenceql/gen.clj/config.edn
+++ b/resources/clj-kondo.exports/io.github.inferenceql/gen.clj/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {gen.dynamic/gen clojure.core/fn}}

--- a/src/gen/dynamic.clj
+++ b/src/gen/dynamic.clj
@@ -186,6 +186,7 @@
 (defmacro gen
   "Defines a generative function."
   [& args]
+  {:clj-kondo/lint-as 'clojure.core/fn}
   (let [name (when (simple-symbol? (first args))
                (first args))
         [params & body] (if name (rest args) args)]

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -19,6 +19,12 @@
         <developer>
             <name>Zane Shelby</name>
         </developer>
+        <developer>
+            <name>Ulrich Schaechtle</name>
+        </developer>
+        <developer>
+            <name>Sam Ritchie</name>
+        </developer>
     </developers>
     <scm>
         <url>https://github.com/InferenceQL/gen.clj</url>

--- a/template/pom.xml
+++ b/template/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>io.github.inferenceql</groupId>
+    <artifactId>gen.clj</artifactId>
+    <name>gen.clj</name>
+    <description>A general-purpose probabilistic programming system with programmable inference.</description>
+    <url>https://github.com/InferenceQL/gen.clj</url>
+    <licenses>
+        <license>
+            <name>MIT</name>
+            <url>http://www.opensource.org/licenses/mit-license.php</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+    <developers>
+        <developer>
+            <name>Zane Shelby</name>
+        </developer>
+    </developers>
+    <scm>
+        <url>https://github.com/InferenceQL/gen.clj</url>
+        <connection>scm:git:git://github.com/InferenceQL/gen.clj.git</connection>
+        <developerConnection>scm:git:ssh://git@github.com/InferenceQL/gen.clj.git</developerConnection>
+    </scm>
+</project>


### PR DESCRIPTION
This PR:

- introduces a `bb.edn` file with tasks for generating and serving the Clerk static build locally and to GitHub Pages or Clerk's Garden static publishing site
- adds the build machinery required to publish releases to Clojars, along with an associated GitHub Action
- adds a `DEVELOPING.md` file
- adds an exportable clj-kondo config that allows the `gen` macro and its internal forms to lint properly
- adds a custom `dev/user.clj` with config for Clerk's watcher mode and static build
- updates the README to reflect this new process