### PR TITLE
Add .dir-locals.el for emacs development config

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,0 +1,7 @@
+((nil
+  . ((cider-default-cljs-repl . node)
+     (cider-preferred-build-tool . clojure-cli)
+     (cider-clojure-cli-aliases . ":test:nextjournal/clerk")
+
+     ;; Custom indentation:
+     (eval . (put-clojure-indent 'gen 1)))))


### PR DESCRIPTION
This is helpful to me, but ALSO for folks running Clerk from the local repository as per the instructions. I think there is a similar thing we can do for VSCode users...