### PR TITLE
Add kixi.stats distribution implementation

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,7 +1,8 @@
 {:paths ["src" "resources"]
 
  :deps
- {org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
+ {kixi/stats {:mvn/version "0.5.5"}
+  org.apache.commons/commons-math3 {:mvn/version "3.6.1"}
   org.clojure/clojure {:mvn/version "1.11.1"}}
 
  :aliases

--- a/src/gen/distribution/commons_math.clj
+++ b/src/gen/distribution/commons_math.clj
@@ -54,20 +54,26 @@
                      0 false
                      1 true)))))
 
-(defn beta-distribution [^double alpha ^double beta]
-  (BetaDistribution. (rng) alpha beta))
+(defn beta-distribution
+  ([] (beta-distribution 1.0 1.0))
+  ([^double alpha ^double beta]
+   (BetaDistribution. (rng) alpha beta)))
 
 (defn gamma-distribution [^double shape ^double scale]
   (GammaDistribution. (rng) shape scale))
 
-(defn normal-distribution [^double mean ^double sd]
-  (NormalDistribution. (rng) mean sd))
+(defn normal-distribution
+  ([] (normal-distribution 0.0 1.0))
+  ([^double mean ^double sd]
+   (NormalDistribution. (rng) mean sd)))
 
-(defn uniform-distribution [^double low ^double high]
-  (UniformRealDistribution. (rng) low high))
+(defn uniform-distribution
+  ([] (uniform-distribution 0.0 1.0))
+  ([^double low ^double high]
+   (UniformRealDistribution. (rng) low high)))
 
 (defn uniform-discrete-distribution [low high]
-  (UniformIntegerDistribution. low high))
+  (UniformIntegerDistribution. (rng) low high))
 
 (defn categorical-distribution [probabilities]
   (let [n  (count probabilities)
@@ -78,7 +84,6 @@
 ;; ## Primitive generative functions
 
 (def bernoulli
-  "Generative function... TODO flesh out."
   (d/->GenerativeFn bernoulli-distribution))
 
 (def beta

--- a/src/gen/distribution/kixi.clj
+++ b/src/gen/distribution/kixi.clj
@@ -1,0 +1,133 @@
+(ns gen.distribution.kixi
+  (:require [gen.distribution :as d]
+            [gen.distribution.math.log-likelihood :as ll]
+            [kixi.stats.distribution :as k])
+  (:import (kixi.stats.distribution Bernoulli Cauchy
+                                    Exponential Beta
+                                    Gamma Normal Uniform)))
+
+;; ## Kixi.stats protocol implementations
+;;
+;; NOTE: If we want to seed the PRNG here, the right way to do it is to create
+;; wrapper types that hold a kixi distribution instance and an RNG. Then,
+;; instead of `draw`, we can call `sample-1` with the distribution and RNG.
+
+
+(extend-type Bernoulli
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (ll/bernoulli (.-p this) v)))
+
+(extend-type Beta
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (ll/beta (.-alpha this)
+             (.-beta this)
+             v)))
+
+(extend-type Cauchy
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (ll/cauchy (.-location this)
+               (.-scale this)
+               v)))
+
+(extend-type Exponential
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (ll/exponential (.-rate this) v)))
+
+(extend-type Uniform
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (let [min (.-a this)
+          max (.-b this)]
+      (ll/uniform min max v))))
+
+(extend-type Gamma
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (ll/gamma (.-shape this)
+              (.-scale this)
+              v)))
+
+(extend-type Normal
+  d/Sample
+  (sample [this] (k/draw this))
+
+  d/LogPDF
+  (logpdf [this v]
+    (ll/gaussian (.-mu this)
+                 (.-sd this)
+                 v)))
+
+;; ## Primitive probability distributions
+
+(defn bernoulli-distribution
+  ([] (bernoulli-distribution 0.5))
+  ([p] (k/bernoulli {:p p})))
+
+(defn beta-distribution
+  ([] (beta-distribution 1.0 1.0))
+  ([alpha beta]
+   (k/beta {:alpha alpha :beta beta})))
+
+(defn cauchy-distribution [location scale]
+  (k/cauchy {:location location :scale scale}))
+
+(defn exponential-distribution [rate]
+  (k/exponential {:rate rate}))
+
+(defn uniform-distribution
+  ([] (uniform-distribution 0.0 1.0))
+  ([lo hi]
+   (k/uniform {:a lo :b hi})))
+
+(defn normal-distribution
+  ([] (normal-distribution 0.0 1.0))
+  ([mu sigma]
+   (k/normal {:mu mu :sd sigma})))
+
+(defn gamma-distribution [shape scale]
+  (k/gamma {:shape shape :scale scale}))
+
+;; ## Primitive generative functions
+
+(def bernoulli
+  (d/->GenerativeFn bernoulli-distribution))
+
+(def beta
+  (d/->GenerativeFn beta-distribution))
+
+(def cauchy
+  (d/->GenerativeFn cauchy-distribution))
+
+(def exponential
+  (d/->GenerativeFn exponential-distribution))
+
+(def uniform
+  (d/->GenerativeFn uniform-distribution))
+
+(def normal
+  (d/->GenerativeFn normal-distribution))
+
+(def gamma
+  (d/->GenerativeFn gamma-distribution))

--- a/test/gen/distribution/kixi_test.clj
+++ b/test/gen/distribution/kixi_test.clj
@@ -1,0 +1,65 @@
+(ns gen.distribution.kixi-test
+  (:require [clojure.math :as math]
+            [clojure.test :refer [deftest is]]
+            [gen]
+            [gen.choice-map]
+            [gen.diff :as diff]
+            [gen.distribution.kixi :as d]
+            [gen.generative-function :as gf]
+            [gen.trace :as trace]))
+
+(deftest bernoulli-call-no-args
+  (is (boolean? (d/bernoulli))))
+
+(deftest bernoulli-call-args
+  (is (boolean? (d/bernoulli 0.5))))
+
+(deftest bernoulli-gf
+  (is (= d/bernoulli (trace/gf (gf/simulate d/bernoulli [])))))
+
+(deftest bernoulli-args
+  (is (= [0.5] (trace/args (gf/simulate d/bernoulli [0.5])))))
+
+(deftest bernoulli-retval
+  (is (boolean? (trace/retval (gf/simulate d/bernoulli [0.5])))))
+
+(deftest bernoulli-choices-noargs
+  (trace/choices (gf/simulate d/bernoulli [])))
+
+(deftest bernoulli-update-weight
+  (is (= 1.0
+         (-> (gf/generate d/bernoulli [0.3] #gen/choice true)
+             (:trace)
+             (trace/update #gen/choice true)
+             (:weight)
+             (math/exp))))
+  (is (= (/ 0.7 0.3)
+         (-> (gf/generate d/bernoulli [0.3] #gen/choice true)
+             (:trace)
+             (trace/update #gen/choice false)
+             (:weight)
+             (math/exp)))))
+
+(deftest bernoulli-update-discard
+  (is (nil?
+       (-> (gf/generate d/bernoulli [0.3] #gen/choice true)
+           (:trace)
+           (trace/update nil)
+           (:discard))))
+  (is (= #gen/choice true
+         (-> (gf/generate d/bernoulli [0.3] #gen/choice true)
+             (:trace)
+             (trace/update #gen/choice false)
+             (:discard)))))
+
+(deftest bernoulli-update-change
+  (is (= diff/unknown-change
+         (-> (gf/generate d/bernoulli [0.3] #gen/choice true)
+             (:trace)
+             (trace/update nil)
+             (:change))))
+  (is (= diff/unknown-change
+         (-> (gf/generate d/bernoulli [0.3] #gen/choice true)
+             (:trace)
+             (trace/update #gen/choice false)
+             (:change)))))


### PR DESCRIPTION
This PR:

- adds a number of distributions based on the `kixi.stats` library
- adds default arities for some commons-math distributions that I had left out.

These are all cljc compatible, but I'll need to wait until I convert everything to cljc so that the tests and other namespace dependencies pass.