### PR TITLE
Remove missing variable from dir-locals

### DIFF
--- a/.dir-locals.el
+++ b/.dir-locals.el
@@ -1,7 +1,4 @@
 ((nil
   . ((cider-default-cljs-repl . node)
      (cider-preferred-build-tool . clojure-cli)
-     (cider-clojure-cli-aliases . ":test:nextjournal/clerk")
-
-     ;; Custom indentation:
-     (eval . (put-clojure-indent 'gen 1)))))
+     (cider-clojure-cli-aliases . ":test:nextjournal/clerk"))))


### PR DESCRIPTION
This seems to have disappeared with a recent clojure-mode update.