### PR TITLE
Add cljc log-likelihood implementations

### DIFF
--- a/.clj-kondo/babashka/fs/config.edn
+++ b/.clj-kondo/babashka/fs/config.edn
@@ -1,0 +1,1 @@
+{:lint-as {babashka.fs/with-temp-dir clojure.core/let}}

--- a/.clj-kondo/com.gfredericks/test.chuck/clj_kondo/com/gfredericks/test/chuck/checking.clj
+++ b/.clj-kondo/com.gfredericks/test.chuck/clj_kondo/com/gfredericks/test/chuck/checking.clj
@@ -1,0 +1,19 @@
+(ns clj-kondo.com.gfredericks.test.chuck.checking
+  (:require
+   [clj-kondo.hooks-api :as api]))
+
+(defn checking
+  [{{:keys [children]} :node}]
+  (let [[_checking desc & opt+bindings+body] children
+        [opts binding-vec & body]             (if (api/vector-node? (first opt+bindings+body))
+                                                (into [(api/map-node {})] opt+bindings+body)
+                                                opt+bindings+body)]
+    (when-not (even? (count (:children binding-vec)))
+      (throw (ex-info "checking requires an even number of bindings" {})))
+    {:node (api/list-node
+            (list*
+             (api/token-node 'let)
+             (api/vector-node (into [(api/token-node (symbol (gensym "_checking-desc"))) desc]
+                                    (:children binding-vec)))
+             opts
+             body))}))

--- a/.clj-kondo/com.gfredericks/test.chuck/config.edn
+++ b/.clj-kondo/com.gfredericks/test.chuck/config.edn
@@ -1,0 +1,4 @@
+{:hooks
+ {:analyze-call
+  {com.gfredericks.test.chuck.clojure-test/checking
+   clj-kondo.com.gfredericks.test.chuck.checking/checking}}}

--- a/.clj-kondo/nextjournal/clerk/config.edn
+++ b/.clj-kondo/nextjournal/clerk/config.edn
@@ -1,0 +1,13 @@
+{:config-in-call {nextjournal.clerk.viewer/->viewer-fn {:linters {:unresolved-symbol {:exclude [clj->js]}
+                                                                  :unresolved-namespace {:exclude [nextjournal.clerk.render
+                                                                                                   nextjournal.clerk.render.code
+                                                                                                   nextjournal.clerk.render.hooks
+                                                                                                   js]}}}
+                  nextjournal.clerk.viewer/->viewer-eval {:linters {:unresolved-symbol {:exclude [clj->js]}
+                                                                    :unresolved-namespace {:exclude [nextjournal.clerk.render
+                                                                                                     nextjournal.clerk.render.code
+                                                                                                     nextjournal.clerk.render.hooks
+                                                                                                     js]}}}}
+ :hooks {:analyze-call {nextjournal.clerk.viewer/->viewer-fn nextjournal.clerk.viewer/->viewer-fn
+                        nextjournal.clerk.viewer/->viewer-eval nextjournal.clerk.viewer/->viewer-fn}}
+ :lint-as {nextjournal.clerk/defcached clojure.core/def}}

--- a/.clj-kondo/nextjournal/clerk/nextjournal/clerk/viewer.clj_kondo
+++ b/.clj-kondo/nextjournal/clerk/nextjournal/clerk/viewer.clj_kondo
@@ -1,0 +1,15 @@
+(ns nextjournal.clerk.viewer
+  (:require [clj-kondo.hooks-api :as api]
+            [clojure.string :as str]))
+
+(defn ->viewer-fn [{:keys [node lang] :as opts}]
+  (let [[_name-node quoted-node] (:children node)
+        quoted-tag (api/tag quoted-node)]
+    (when (= :quote quoted-tag)
+      (let [quoted-node
+            (with-meta
+              {:tag :syntax-quote
+               :children (:children quoted-node)}
+              (assoc (meta node)
+                     :clj-kondo/ignore [:unresolved-var]))]
+        {:node quoted-node}))))

--- a/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
+++ b/.clj-kondo/rewrite-clj/rewrite-clj/config.edn
@@ -1,0 +1,5 @@
+{:lint-as
+ {rewrite-clj.zip/subedit-> clojure.core/->
+  rewrite-clj.zip/subedit->> clojure.core/->>
+  rewrite-clj.zip/edit-> clojure.core/->
+  rewrite-clj.zip/edit->> clojure.core/->>}}

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -41,7 +41,7 @@ jobs:
             CLOVERAGE_VERSION=1.2.4 clojure -M:test:coverage --codecov || :
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
-          file: ./target/coverage/codecov.json
+          files: ./target/coverage/codecov.json

--- a/deps.edn
+++ b/deps.edn
@@ -20,7 +20,10 @@
     org.clojure/clojurescript {:mvn/version "1.11.60"}}}
 
   :test
-  {:extra-paths ["test"]}
+  {:extra-paths ["test"]
+   :extra-deps {com.gfredericks/test.chuck {:mvn/version "0.2.14"}
+                org.clojure/test.check {:mvn/version "1.1.1"}
+                same/ish {:mvn/version "0.1.6"}}}
 
   ;; See https://github.com/cognitect-labs/test-runner for invocation
   ;; instructions, or call `clojure -X:test:runner`.

--- a/src/gen/distribution/math/log_likelihood.cljc
+++ b/src/gen/distribution/math/log_likelihood.cljc
@@ -1,0 +1,176 @@
+(ns gen.distribution.math.log-likelihood
+  "Log-likelihood implementations for various primitive distributions.")
+
+;; ## Helpful constants
+;;
+;; These come in handy in the implementations below and are worth caching.
+
+(def ^:no-doc log-pi
+  (Math/log Math/PI))
+
+(def ^:no-doc log-2pi
+  (Math/log (* 2 Math/PI)))
+
+(def ^:no-doc sqrt-2pi
+  (Math/sqrt (* 2 Math/PI)))
+
+;; ## Log-likelihood implementations
+
+(def ^:no-doc gamma-coefficients
+  "Coefficients for the Lanczos approximation to the natural log of the Gamma
+  function described in [section 6.1 of Numerical
+  Recipes](http://phys.uri.edu/nigh/NumRec/bookfpdf/f6-1.pdf)."
+  [76.18009172947146
+   -86.50532032941677
+   24.01409824083091
+   -1.231739572450155
+   0.1208650973866179e-2
+   -0.5395239384953e-5])
+
+(defn ^:no-doc log-gamma-fn
+  "Returns the natural log of the value of the [Gamma
+  function](https://en.wikipedia.org/wiki/Gamma_function) evaluated at `x`
+
+  This function implements the Lanczos approximation described in [section 6.1
+  of Numerical Recipes](http://phys.uri.edu/nigh/NumRec/bookfpdf/f6-1.pdf)."
+  [x]
+  (let [tmp (+ x 5.5)
+        tmp (- (* (+ x 0.5) (Math/log tmp)) tmp)
+        n   (dec (count gamma-coefficients))
+        ser (loop [i   0
+                   x+1 (inc x)
+                   acc 1.000000000190015]
+              (if (> i n)
+                acc
+                (let [coef (nth gamma-coefficients i nil)]
+                  (recur (inc i)
+                         (inc x+1)
+                         (+ acc (/ coef x+1))))))]
+    (+ tmp (Math/log (* sqrt-2pi (/ ser x))))))
+
+(defn gamma
+  "Returns the log-likelihood of the [Gamma
+  distribution](https://en.wikipedia.org//wiki/Gamma_distribution) parameterized
+  by `shape` and `scale` at the value `v`.
+
+  The implementation follows the algorithm described on the Gamma
+  distribution's [Wikipedia
+  page](https://en.wikipedia.org//wiki/Gamma_distribution#Maximum_likelihood_estimation)."
+  [shape scale v]
+  (if (pos? v)
+    (- (* (dec shape) (Math/log v))
+       (/ v scale)
+       (log-gamma-fn shape)
+       (* shape (Math/log scale)))
+    ##-Inf))
+
+(defn log-beta-fn
+  "Returns the natural log of the value of the [Beta
+  function](https://en.wikipedia.org/wiki/Beta_function) evaluated at inputs `a`
+  and `b`."
+  [a b]
+  (- (+ (log-gamma-fn a)
+        (log-gamma-fn b))
+     (log-gamma-fn (+ a b))))
+
+(defn beta
+  "Returns the log-likelihood of the [Beta
+  distribution](https://en.wikipedia.org/wiki/Beta_distribution) parameterized by
+  `alpha` and `beta` at the value `v`.
+
+  The implementation follows the algorithm described on the Beta
+  distribution's [Wikipedia
+  page](https://en.wikipedia.org/wiki/Beta_distribution#Probability_density_function)."
+  [alpha beta v]
+  (if (< 0 v 1)
+    (- (+ (* (- alpha 1) (Math/log v))
+          (* (- beta alpha) (Math/log (- 1 v))))
+       (log-beta-fn alpha beta))
+    ##-Inf))
+
+(defn bernoulli
+  "Returns the log-likelihood of a [Bernoulli
+  distribution](https://en.wikipedia.org/wiki/Bernoulli_distribution)
+  parameterized by probability `p` at the boolean value `v`."
+  [p v]
+  (Math/log
+   (if v p (- 1.0 p))))
+
+(defn cauchy
+  "Returns the log-likelihood of a [Cauchy
+  distribution](https://en.wikipedia.org/wiki/Cauchy_distribution) parameterized
+  by `scale` and `location` at the value `v`.
+
+  The implementation follows the algorithm described on the Cauchy
+  distribution's [Wikipedia
+  page](https://en.wikipedia.org/wiki/Cauchy_distribution#Probability_density_function_(PDF))."
+  [scale location v]
+  (let [normalized (/ (- v location) scale)
+        norm**2    (* normalized normalized)]
+    (- (- log-pi)
+       (Math/log scale)
+       (Math/log (+ 1 norm**2)))))
+
+(defn delta
+  "Returns the log-likelihood of the [Dirac delta
+  distribution](https://en.wikipedia.org/wiki/Dirac_delta_function) centered
+  around `center` at the value `v`."
+  [param v]
+  (if (= param v) 0 ##-Inf))
+
+(defn exponential
+  "Returns the log-likelihood of the [exponential
+  distribution](https://en.wikipedia.org/wiki/Exponential_distribution) with
+  rate parameter `rate` at the value `v`."
+  [rate v]
+  (if (>= v 0)
+    (- (Math/log rate) (* rate v))
+    ##-Inf))
+
+(defn laplace
+  "Returns the log-likelihood of the [Laplace
+  distribution](https://en.wikipedia.org/wiki/Laplace_distribution) with
+  `location` and `scale` parameters at the value `v`.
+
+  The implementation follows the algorithm described on the Laplace
+  distribution's [Wikipedia
+  page](https://en.wikipedia.org/wiki/Laplace_distribution#Probability_density_function)."
+  [location scale v]
+  (- (+ (Math/log (* 2.0 scale))
+        (/ (Math/abs ^double (- v location))
+           scale))))
+
+(defn gaussian
+  "Returns the log-likelihood of the [Gaussian
+  distribution](https://en.wikipedia.org/wiki/Gaussian_distribution) with
+  mean `mu` and standard deviation `sigma` at the value `v`.
+
+  The implementation follows the algorithm described on the Gaussian
+  distribution's [Wikipedia
+  page](https://en.wikipedia.org/wiki/Normal_distribution#Operations_on_a_single_normal_variable):
+
+  Given $z = \\left(\\frac{x-\\mu}{\\sigma}\\right)^2$:
+
+  $$
+  \\begin{aligned}
+  \\ln p(x) &= -\\frac{1}{2}z^2 - \\ln (\\sigma \\sqrt{2\\pi}) \\\\
+            &= -\\frac{1}{2}\\left(z^2 + 2 \\ln (\\sigma \\sqrt{2\\pi}) \\right) \\\\
+            &= -\\frac{1}{2}\\left(z^2 + \\ln (\\sigma^2) + \\ln (2\\pi) \\right)
+  \\end{aligned}
+  $$"
+  [mu sigma v]
+  (let [v-mu     (- v mu)
+        v-mu-sq  (* v-mu v-mu)
+        variance (* sigma sigma)]
+    (* -0.5 (+ log-2pi
+               (Math/log variance)
+               (/ v-mu-sq variance)))))
+
+(defn uniform
+  "Returns the log-likelihood of the continuous [uniform
+  distribution](https://en.wikipedia.org/wiki/uniform_distribution) with
+  inclusive lower bound `a` and inclusive upper bound `b` at the value `v`."
+  [a b v]
+  (if (<= a v b)
+    (- (Math/log (- b a)))
+    ##-Inf))

--- a/src/gen/distribution/math/log_likelihood.cljc
+++ b/src/gen/distribution/math/log_likelihood.cljc
@@ -82,6 +82,7 @@
   distribution's [Wikipedia
   page](https://en.wikipedia.org/wiki/Beta_distribution#Probability_density_function)."
   [alpha beta v]
+  {:pre [(pos? alpha) (pos? beta)]}
   (if (< 0 v 1)
     (- (+ (* (- alpha 1) (Math/log v))
           (* (- beta alpha) (Math/log (- 1 v))))
@@ -93,8 +94,8 @@
   distribution](https://en.wikipedia.org/wiki/Bernoulli_distribution)
   parameterized by probability `p` at the boolean value `v`."
   [p v]
-  (Math/log
-   (if v p (- 1.0 p))))
+  {:pre [(<= 0 p 1)]}
+  (Math/log (if v p (- 1.0 p))))
 
 (defn cauchy
   "Returns the log-likelihood of a [Cauchy
@@ -115,8 +116,8 @@
   "Returns the log-likelihood of the [Dirac delta
   distribution](https://en.wikipedia.org/wiki/Dirac_delta_function) centered
   around `center` at the value `v`."
-  [param v]
-  (if (= param v) 0 ##-Inf))
+  [center v]
+  (if (= center v) 0.0 ##-Inf))
 
 (defn exponential
   "Returns the log-likelihood of the [exponential
@@ -166,10 +167,12 @@
                (Math/log variance)
                (/ v-mu-sq variance)))))
 
+
 (defn uniform
   "Returns the log-likelihood of the continuous [uniform
-  distribution](https://en.wikipedia.org/wiki/uniform_distribution) with
-  inclusive lower bound `a` and inclusive upper bound `b` at the value `v`."
+  distribution](https://en.wikipedia.org/wiki/Continuous_uniform_distribution)
+  with inclusive lower bound `a` and inclusive upper bound `b` at the value
+  `v`."
   [a b v]
   (if (<= a v b)
     (- (Math/log (- b a)))

--- a/test/gen/distribution/math/log_likelihood_test.cljc
+++ b/test/gen/distribution/math/log_likelihood_test.cljc
@@ -1,16 +1,164 @@
 (ns gen.distribution.math.log-likelihood-test
   (:require [com.gfredericks.test.chuck.clojure-test :refer [checking]]
-            [clojure.test :refer [deftest is]]
+            [clojure.test :refer [deftest is testing]]
             [clojure.test.check.generators :as gen]
-            [gen.distribution.math.log-likelihood :as ll]))
+            [gen.distribution.math.log-likelihood :as ll]
+            [same.core :refer [ish? zeroish? with-comparator]]))
 
-(def nonzero-double
+(defn within
+  "Returns a function that tests whether two values are within `eps` of each
+  other."
+  [^double eps]
+  (fn [^double x ^double y]
+    (< (Math/abs (- x y)) eps)))
+
+(defn factorial
+  "Factorial implementation for testing."
+  [n]
+  (if (zero? n)
+    1
+    (* n (factorial (dec n)))))
+
+(defn gen-double [min max]
   (gen/double*
-   {:min 0.001 :max 10 :infinite? false :NaN? false}))
+   {:min min :max max :infinite? false :NaN? false}))
+
+(deftest log-gamma-fn-tests
+  (testing "log-Gamma ~matches log(factorial)"
+    (with-comparator (within 1e-11)
+      (doseq [n (range 1 15)]
+        (is (ish? (Math/log (factorial (dec n)))
+                  (ll/log-gamma-fn n))))))
+
+
+  (with-comparator (within 1e-12)
+    (checking "Euler's reflection formula"
+              [z (gen-double 0.001 0.999)]
+              (is (ish? (+ (ll/log-gamma-fn (- 1 z))
+                           (ll/log-gamma-fn z))
+                        (- ll/log-pi
+                           (Math/log
+                            (Math/sin (* Math/PI z)))))))))
+
+(deftest gamma-tests
+  (testing "spot checks"
+    (is (= -6.391804444241573 (ll/gamma 0.001 1 0.4)))
+    (is (= -393.0922447210179 (ll/gamma 1 0.001 0.4)))))
 
 (deftest beta-tests
   (checking "(log of the) Beta function is symmetrical"
-            [a nonzero-double
-             b nonzero-double]
+            [a (gen-double 0.01 2)
+             b (gen-double 0.01 2)]
             (is (= (ll/log-beta-fn a b)
-                   (ll/log-beta-fn b a)))))
+                   (ll/log-beta-fn b a))))
+
+  (testing "spot checks"
+    (is (= -6.5026956359820804 (ll/beta 0.001 1 0.4)))
+    (is (= -6.397440480839912 (ll/beta 1 0.001 0.4)))))
+
+(deftest bernoulli-tests
+  (checking "Bernoulli properties"
+            [p (gen-double 0 1)
+             v gen/boolean]
+            (is (= (ll/bernoulli 0.5 v)
+                   (ll/bernoulli 0.5 (not v)))
+                "Fair coin has equal chance")
+
+            (is (ish? 1.0
+                      (+ (Math/exp (ll/bernoulli p v))
+                         (Math/exp (ll/bernoulli p (not v)))))
+                "All options sum to 1")))
+
+(deftest cauchy-tests
+  (checking "Cauchy properties"
+            [scale (gen-double 0.001 100)
+             v     (gen-double -100 100)]
+            (is (= (ll/cauchy scale 0 v)
+                   (ll/cauchy scale 0 (- v)))
+                "symmetric about location"))
+
+  (testing "spot checks"
+    (is (= -1.1447298858494002 (ll/cauchy 1 1 1)))
+    (is (= -1.8378770664093453 (ll/cauchy 2 2 2)))))
+
+(deftest delta-tests
+  (checking "Delta properties"
+            [center (gen-double -100 100)
+             v      (gen-double -100 100)]
+            (if (= center v)
+              (is (= 0.0    (ll/delta center v)))
+              (is (= ##-Inf (ll/delta center v))))))
+
+(deftest exponential-tests
+  (checking "exponential will never produce negative values"
+            [rate (gen-double -100 100)
+             v    (gen-double -100 -0.00001)]
+            (is (= ##-Inf (ll/exponential rate v))))
+
+  (checking "rate 1.0 produces -v"
+            [v (gen-double 0 100)]
+            (is (= (- v) (ll/exponential 1.0 v))))
+
+  (checking "rate 0.0 produces #-Inf"
+            [v (gen-double -100 100)]
+            (is (= ##-Inf (ll/exponential 0.0 v))))
+
+  (testing "spot checks"
+    (is (= -3.3068528194400546 (ll/exponential 2.0 2.0)))
+    (is (= -5.306852819440055  (ll/exponential 2.0 3.0)))))
+
+(deftest laplace-test
+  (checking "Laplace properties"
+            [v (gen-double -10 10)]
+            (let [log-l (ll/laplace 0 1 v)]
+              (is (if (neg? v)
+                    (is (= log-l (- v (Math/log 2))))
+                    (is (= log-l (- (- v) (Math/log 2)))))
+                  "location 0, scale 1"))
+
+            (is (= (ll/laplace 0 1 v)
+                   (ll/laplace 0 1 (- v)))
+                "symmetric about location"))
+
+  (checking "Laplace with scale 1, location == v"
+            [v (gen-double -10 10)]
+            (is (is (= (- (Math/log 2))
+                       (ll/laplace v 1 v)))))
+
+  (testing "spot checks"
+    (is (= -1.6931471805599454 (ll/laplace 2 1 1)))
+    (is (= -1.8862943611198906 (ll/laplace 0 2 1)))
+    (is (= 4.214608098422191   (ll/laplace 0 0.001 0.002)))))
+
+(deftest gaussian-tests
+  (checking "Gaussian properties"
+            [mu    (gen-double -10 10)
+             sigma (gen-double 0.001 10)
+             v     (gen-double -100 100)
+             shift (gen-double -10 10)]
+            (is (ish? (ll/gaussian 0.0 sigma v)
+                      (ll/gaussian 0.0 sigma (- v)))
+                "Gaussian is symmetric about the mean")
+
+            (is (ish? (ll/gaussian mu sigma v)
+                      (ll/gaussian (+ mu shift) sigma (+ v shift)))
+                "shifting by the mean is a symmetry"))
+
+
+  (testing "spot checks"
+    (is (= -1.0439385332046727 (ll/gaussian 0 1 0.5)))
+    (is (= -1.643335713764618 (ll/gaussian 0 2 0.5)))
+    (is (= -1.612085713764618 (ll/gaussian 0 2 0)))))
+
+(deftest uniform-tests
+  (checking "(log of the) Beta function is symmetrical"
+            [min (gen-double -10 0)
+             max (gen-double 0 10)
+             v   (gen-double -10 10)]
+            (let [log-l (ll/uniform min max v)]
+              (if (<= min v max)
+                (is (zeroish?
+                     (+ log-l (Math/log (- max min))))
+                    "Inside the bounds, log-l*range == 1.0")
+                (is (= ##-Inf log-l)
+                    "Outside the bounds, (log 0.0)")))))

--- a/test/gen/distribution/math/log_likelihood_test.cljc
+++ b/test/gen/distribution/math/log_likelihood_test.cljc
@@ -1,0 +1,16 @@
+(ns gen.distribution.math.log-likelihood-test
+  (:require [com.gfredericks.test.chuck.clojure-test :refer [checking]]
+            [clojure.test :refer [deftest is]]
+            [clojure.test.check.generators :as gen]
+            [gen.distribution.math.log-likelihood :as ll]))
+
+(def nonzero-double
+  (gen/double*
+   {:min 0.001 :max 10 :infinite? false :NaN? false}))
+
+(deftest beta-tests
+  (checking "(log of the) Beta function is symmetrical"
+            [a nonzero-double
+             b nonzero-double]
+            (is (= (ll/log-beta-fn a b)
+                   (ll/log-beta-fn b a)))))


### PR DESCRIPTION
These are required for the `kixi.stats` cljc distributions, as well as for the `SplittableRandom` implementation, and a similar `Math.Random` version for JavaScript.

I'll add more unit tests locking in specific values, but I want to see about adding generative tests that lock in properties we care about.