### PR TITLE
remove bottomless pr-str in Trace

### DIFF
--- a/src/gen/dynamic/trace.clj
+++ b/src/gen/dynamic/trace.clj
@@ -59,7 +59,6 @@
 
   Object
   (equals [this that] (= this that))
-  (toString [this] (pr-str this))
 
   IFn
   (invoke [this k] (.valAt this k))


### PR DESCRIPTION
I didn't realize when I added this that this doesn't bottom out in a print-method, and therefore causes a stack overflow. Let's remove it for now until we have a reason to override the default rep.