### PR TITLE
Move trace's Update implementation into deftype

### DIFF
--- a/src/gen/dynamic/choice_map.cljc
+++ b/src/gen/dynamic/choice_map.cljc
@@ -176,7 +176,10 @@
                     (.iterator ^Iterable (map auto-get-choice m)))
 
        Iterable
-       (iterator [this] (.iterator ^Iterable (.seq this)))]))
+       (iterator [this]
+                 (if-let [xs (.seq this)]
+                   (.iterator ^Iterable xs)
+                   (.iterator {})))]))
 
 (defn unwrap
   "If `m` is a [[Choice]] or [[ChoiceMap]], returns `m` stripped of its wrappers.

--- a/test/gen/dynamic/trace_test.cljc
+++ b/test/gen/dynamic/trace_test.cljc
@@ -31,45 +31,45 @@
   (let [trace (dynamic.trace/trace (gen []) [])]
     (is (nil? (trace :addr))))
   (let [trace (-> (dynamic.trace/trace (gen []) [])
-                  (dynamic.trace/assoc-subtrace :addr (choice-trace :x)))]
+                  (dynamic.trace/assoc :addr (choice-trace :x)))]
     (is (= :x (trace :addr)))))
 
 (deftest keys
   (is (= #{:addr}
          (-> (dynamic.trace/trace (gen []) [])
-             (dynamic.trace/assoc-subtrace :addr (choice-trace :x))
+             (dynamic.trace/assoc :addr (choice-trace :x))
              (clojure/keys)
              (set))))
   (is (= #{:addr1 :addr2}
          (-> (dynamic.trace/trace (gen []) [])
-             (dynamic.trace/assoc-subtrace :addr1 (choice-trace :x))
-             (dynamic.trace/assoc-subtrace :addr2 (choice-trace :y))
+             (dynamic.trace/assoc :addr1 (choice-trace :x))
+             (dynamic.trace/assoc :addr2 (choice-trace :y))
              (clojure/keys)
              (set)))))
 
 (deftest vals
   (is (= #{:x}
          (-> (dynamic.trace/trace (gen []) [])
-             (dynamic.trace/assoc-subtrace :addr (choice-trace :x))
+             (dynamic.trace/assoc :addr (choice-trace :x))
              (clojure/vals)
              (set))))
   (is (= #{:x :y}
          (-> (dynamic.trace/trace (gen []) [])
-             (dynamic.trace/assoc-subtrace :addr1 (choice-trace :x))
-             (dynamic.trace/assoc-subtrace :addr2 (choice-trace :y))
+             (dynamic.trace/assoc :addr1 (choice-trace :x))
+             (dynamic.trace/assoc :addr2 (choice-trace :y))
              (clojure/vals)
              (set)))))
 
 (deftest seq
   (let [trace (-> (dynamic.trace/trace (gen []) [])
-                  (dynamic.trace/assoc-subtrace :addr0 (choice-trace :x))
-                  (dynamic.trace/assoc-subtrace :addr1 (choice-trace :y))
-                  (dynamic.trace/assoc-subtrace :addr2 (choice-trace :z)))]
+                  (dynamic.trace/assoc :addr0 (choice-trace :x))
+                  (dynamic.trace/assoc :addr1 (choice-trace :y))
+                  (dynamic.trace/assoc :addr2 (choice-trace :z)))]
     (is (every? map-entry? (clojure/seq trace)))))
 
 (deftest get
   (let [trace (dynamic.trace/trace (gen []) [])]
     (is (nil? (clojure/get trace :addr))))
   (let [trace (-> (dynamic.trace/trace (gen []) [])
-                  (dynamic.trace/assoc-subtrace :addr (choice-trace :x)))]
+                  (dynamic.trace/assoc :addr (choice-trace :x)))]
     (is (= :x (clojure/get trace :addr)))))


### PR DESCRIPTION
This PR:

- Adds "fail fast" behavior to any `dynamic.trace/*trace*` call that already has a value registered at the passed `k`
- Renames `gen.dynamic.trace/assoc-subtrace` to `assoc`
- Moves the implementation of `trace/Update` into `gen.dynamic.trace`