### PR TITLE
Add SCI-compatible accessors for *trace* and *splice*

### DIFF
--- a/src/gen/dynamic.cljc
+++ b/src/gen/dynamic.cljc
@@ -208,13 +208,13 @@
                                  (if-not (valid-trace-form? form)
                                    (throw (ex-info "Malformed trace expression." {:form form}))
                                    (let [[addr [gf & args]] (rest form)]
-                                     `(dynamic.trace/*trace* ~addr ~gf ~(vec args))))
+                                     `((dynamic.trace/active-trace) ~addr ~gf ~(vec args))))
 
                                  (splice-form? form)
                                  (if-not (valid-splice-form? form)
                                    (throw (ex-info "Malformed splice expression." {:form form}))
                                    (let [[[gf & args]] (rest form)]
-                                     `(dynamic.trace/*splice* ~gf ~(vec args))))
+                                     `((dynamic.trace/active-splice) ~gf ~(vec args))))
 
                                  :else
                                  form))

--- a/src/gen/dynamic/trace.cljc
+++ b/src/gen/dynamic/trace.cljc
@@ -27,6 +27,23 @@
   like `gf/simulate`, `gf/generate`, `trace/update`, etc."
   no-op)
 
+(defn active-trace
+  "Returns the currently-active tracing function, bound to [[*trace*]].
+
+  NOTE: Prefer `([[active-trace]])` to `[[*trace*]]`, as direct access to
+  `[[*trace*]]` won't reflect new bindings when accessed inside of an SCI
+  environment."
+  [] *trace*)
+
+(defn active-splice
+  "Returns the currently-active tracing function, bound to [[*splice*]].
+
+  NOTE: Prefer `([[active-splice]])` to `[[*splice*]]`, as direct access to
+  `[[*splice*]]` won't reflect new bindings when accessed inside of an SCI
+  environment."
+  []
+  *splice*)
+
 (defmacro without-tracing
   [& body]
   `(binding [*trace* no-op

--- a/test/gen/dynamic/trace_test.cljc
+++ b/test/gen/dynamic/trace_test.cljc
@@ -8,6 +8,16 @@
             [gen.dynamic.trace :as dynamic.trace]
             [gen.trace :as trace]))
 
+(deftest binding-tests
+  (letfn [(f [_] "hi!")]
+    (binding [dynamic.trace/*trace* f
+              dynamic.trace/*splice* f]
+      (is (= f (dynamic.trace/active-trace))
+          "active-trace reflects dynamic bindings")
+
+      (is (= f (dynamic.trace/active-splice))
+          "active-splice reflects dynamic bindings"))))
+
 (defn choice-trace
   [x]
   (reify trace/Choices


### PR DESCRIPTION
When code's used via SCI, these dynamic variables are bound OUTSIDE the SCI environment, and those bindings are not reflected when code `eval`ed via SCI accesses them directly.

By accessing `*trace*` and `*splice*` through the new `active-trace` and `active-splice`, code inside SCI can see dynamic bindings that occur outside of SCI.

Once I add the SCI namespaces we'll get some tests in that check that this is true.