### PR TITLE
Replace gen with fn, gen.{trace,splice} => gen.dynamic.{trace!,splice!}

### DIFF
--- a/examples/intro_to_modeling.clj
+++ b/examples/intro_to_modeling.clj
@@ -159,7 +159,7 @@
 ;; special syntax that annotates them with an _address_:
 
 ;; ``` clojure
-;; (gen/trace addr (distribution parameters))
+;; (gen/trace addr distribution parameters)
 ;; ```
 
 ;; A simple example of such an invocation is a normal distribution parametrized
@@ -169,7 +169,7 @@
 ;; (require '[gen.distribution.commons-math :as dist])
 ;; ```
 
-(def my-variable (gen/trace :my-variable-address (dist/normal 0 1)))
+(def my-variable (gen/trace :my-variable-address dist/normal 0 1))
 
 ;; Every random choice must be given an _address_, which can be an arbitrary
 ;; value—but we often use a keyword.  (`:my-variable-address` is a keyword in
@@ -177,9 +177,9 @@
 ;; random choice, which is distinct from the name of the variable. For example,
 ;; consider the following code:
 
-(let [x (gen/trace :initial-x (dist/normal 0 1))]
+(let [x (gen/trace :initial-x dist/normal 0 1)]
 (if (< x 0)
-  (+ x (gen/trace :addition-to-x (dist/normal 2 1)))
+  (+ x (gen/trace :addition-to-x dist/normal 2 1))
   x))
 
 ;; This code manipulates a single variable, `x`, but may make up to two random
@@ -192,7 +192,7 @@
 
 ;; ```Clojure
 ;; # INVALID:
-;; (def my-variable (gen/trace :not-a-random-choice (clojure.math/sin x)))
+;; (def my-variable (gen/trace :not-a-random-choice clojure.math/sin x))
 ;; ```
 
 ;; (We will see a bit later that it is _also_ possible to use gen/trace to
@@ -226,8 +226,8 @@
   ;; prior beliefs about the parameters: in this case, that neither the slope
   ;; nor the intercept will be more than a couple points away from 0.
 
-  (let [slope (gen/trace :slope (dist/normal 0 1))
-        intercept (gen/trace :intercept (dist/normal 0 2))
+  (let [slope (gen/trace :slope dist/normal 0 1)
+        intercept (gen/trace :intercept dist/normal 0 2)
 
         ;; We define a function to compute y for a given x.
 
@@ -239,7 +239,7 @@
     ;; the x coordinates in our input vector.
 
     (doseq [[i x] (map vector (range) xs)]
-      (gen/trace [:y i] (dist/normal (y x) 0.1)))
+      (gen/trace [:y i] dist/normal (y x) 0.1))
 
     ;; Most of the time, we don't care about the return
     ;; value of a model, only the random choices it makes.
@@ -455,7 +455,7 @@ math/PI
 
       (dotimes [i (count xs)]
         (let [x (nth xs i)]
-          (gen/trace [:y i] (dist/normal (y x) 0.1))))
+          (gen/trace [:y i] dist/normal (y x) 0.1)))
 
       y))) ; We return the `y` function so it can be used for plotting, below.
 
@@ -496,9 +496,9 @@ math/PI
 (comment
   (def sine-model
     (gen [xs]
-      (let [period (gen/trace :period (dist/gamma 1 1))
-            amplitude (gen/trace :amplitude (dist/gamma 1 1))
-            phase (gen/trace :phase (dist/uniform 0 (* 2 math/PI)))
+      (let [period (gen/trace :period dist/gamma 1 1)
+            amplitude (gen/trace :amplitude dist/gamma 1 1)
+            phase (gen/trace :phase dist/uniform 0 (* 2 math/PI))
 
             ;; Define a deteriministic sine wave with the values above.
             y (fn  [x]
@@ -510,7 +510,7 @@ math/PI
 
         (dotimes [i (count xs)]
           (let [x (nth xs i)]
-            (gen/trace [:y i] (dist/normal (y x) 0.1))))
+            (gen/trace [:y i] dist/normal (y x) 0.1)))
 
         y))))
 
@@ -789,14 +789,14 @@ math/PI
 ^{::clerk/visibility {:result :hide}}
 (def line-model-fancy
   (gen [xs]
-    (let [slope (gen/trace :slope (dist/normal 0 1))
-          intercept (gen/trace :intercept (dist/normal 0 2))
+    (let [slope (gen/trace :slope dist/normal 0 1)
+          intercept (gen/trace :intercept dist/normal 0 2)
           y (fn [x]
               (+ (* slope x)
                  intercept))
-          noise (gen/trace :noise (dist/gamma 1 1))]
+          noise (gen/trace :noise dist/gamma 1 1)]
       (doseq [[i x] (map-indexed vector xs)]
-        (gen/trace [:y i] (dist/normal (y x) noise)))
+        (gen/trace [:y i] dist/normal (y x) noise))
       y)))
 
 ;; Then, we compare the predictions using inference of the unmodified and
@@ -849,7 +849,7 @@ math/PI
               ;; < your code here >
               x)]
       (doseq [[i x] (map-indexed vector xs)]
-        (gen/trace [:y i] (dist/normal (y x) 0.1)))
+        (gen/trace [:y i] dist/normal (y x) 0.1))
       y)))
 
 ;; Experiment with the vaue of `ex-4-1-computation` below.
@@ -874,10 +874,10 @@ math/PI
 (comment
   (def sine-model-fancy
     (gen [xs]
-      (let [period (gen/trace :period (dist/gamma 5 1))
-            amplitude (gen/trace :amplitude (dist/gamma 1 1))
-            phase (gen/trace :phase (dist/uniform 0 (* 2 math/PI)))
-            noise (gen/trace :noise (dist/gamma 1 1))
+      (let [period (gen/trace :period dist/gamma 5 1)
+            amplitude (gen/trace :amplitude dist/gamma 1 1)
+            phase (gen/trace :phase dist/uniform 0 (* 2 math/PI))
+            noise (gen/trace :noise dist/gamma 1 1)
             y (fn [x]
                 (* amplitude
                    (math/sin (+ (* x
@@ -885,7 +885,7 @@ math/PI
                                       period))
                                 phase))))]
         (doseq [[i x] (map-indexed vector xs)]
-          (gen/trace [:y i] (dist/normal (y x) noise))))
+          (gen/trace [:y i] dist/normal (y x) noise)))
       y)))
 
 ;; ## 5. Calling other generative functions
@@ -900,8 +900,8 @@ math/PI
 ;; ways:
 
 ;; 1. **(NOT RECOMMENDED)** using regular Clojure function call syntax: `(f x)`
-;; 2. using `gen/trace` with an address for the call: `(gen/trace :addr (f x))`
-;; 3. using `gen/splice`, which does not require an address: `(gen/splice (f x))`
+;; 2. using `gen/trace` with an address for the call: `(gen/trace :addr f x)` 3.
+;; using `gen/splice`, which does not require an address: `(gen/splice f x)`
 
 ;; When invoking using regular function call syntax, the random choices made by
 ;; the callee function are not traced at all, and Gen cannot reason about them
@@ -911,26 +911,26 @@ math/PI
 ;; will have a choice called `:f-choice` too.  Note that a downside of this is
 ;; that if `f` is called _twice_ by the same caller, then the two choices called
 ;; `:f-choice` will clash, leading to an error. In this case, it is best to
-;; provide an address (`(gen/trace addr (f))`): `f`'s random choices will be
+;; provide an address (`(gen/trace addr f)`): `f`'s random choices will be
 ;; placed under the _key_ `addr`.
 
 (def foo
   (gen []
-    (gen/trace :y (dist/normal 0 1))))
+    (gen/trace :y dist/normal 0 1)))
 
 (def bar
   (gen []
-    (gen/trace :x (dist/bernoulli 0.5))
+    (gen/trace :x dist/bernoulli 0.5)
     ;; Call `foo` with `gen/splice`. Its choices (`:y`) will appear directly
     ;; within the trace of `bar`.
-    (gen/splice (foo))))
+    (gen/splice foo)))
 
 (def bar-with-key
   (gen []
-    (gen/trace :x (dist/bernoulli 0.5))
+    (gen/trace :x dist/bernoulli 0.5)
     ;; Call `foo` with the address `:z`.  The internal choice `:y` of `foo` will
     ;; appear in our trace at the hierarchical address `[:z :y]`.
-    (gen/trace :z (foo))))
+    (gen/trace :z foo)))
 
 ;; We first show the addresses sampled by `bar`:
 
@@ -956,13 +956,13 @@ math/PI
 
 (def combined-model
   (gen [xs]
-    (if (gen/trace :is-line (dist/bernoulli 0.5))
+    (if (gen/trace :is-line dist/bernoulli 0.5)
       ;; Call `line-model-fancy` on xs, and import its random choices directly
       ;; into our trace.
-      (gen/splice (line-model-fancy xs))
+      (gen/splice line-model-fancy xs)
       ;; Call `sine-model-fancy` on xs, and import its random choices directly
       ;; into our trace.
-      (gen/splice (sine-model-fancy xs)))))
+      (gen/splice sine-model-fancy xs))))
 
 ;; We visualize some traces, and see that sometimes it samples linear data and
 ;; other times sinusoidal data.
@@ -1096,15 +1096,15 @@ math/PI
 
 (def generate-segments
   (gen [lower upper]
-    (if (gen/trace :is-leaf (dist/bernoulli 0.7))
-      (let [value (gen/trace :value (dist/normal 0 1))]
+    (if (gen/trace :is-leaf dist/bernoulli 0.7)
+      (let [value (gen/trace :value dist/normal 0 1)]
         #:node{:interval [lower upper] :value value})
-      (let [frac (gen/trace :frac (dist/beta 2 2))
+      (let [frac (gen/trace :frac dist/beta 2 2)
             mid (+ lower
                    (* (- upper lower)
                       frac))
-            left (gen/trace :left (generate-segments lower mid))
-            right (gen/trace :right (generate-segments mid upper))]
+            left (gen/trace :left generate-segments lower mid)
+            right (gen/trace :right generate-segments mid upper)]
         #:node{:interval [lower upper]
                :left left
                :right right}))))
@@ -1189,11 +1189,11 @@ math/PI
   (gen [xs]
     (let [lower (apply min xs)
           upper (apply max xs)
-          node (gen/trace :tree (generate-segments lower upper))
-          noise (gen/trace :noise (dist/gamma 0.5 0.5))]
+          node (gen/trace :tree generate-segments lower upper)
+          noise (gen/trace :noise dist/gamma 0.5 0.5)]
       (doseq [[i x] (map-indexed vector xs)]
-        (gen/trace [:y i] (dist/normal (get-value-at x node)
-                                       noise)))
+        (gen/trace [:y i] dist/normal (get-value-at x node)
+                                       noise))
       node)))
 
 ;; We write a visualization for `changepoint-model` below:

--- a/examples/introduction.clj
+++ b/examples/introduction.clj
@@ -246,16 +246,16 @@
 
 (def gen-f
   (gen [p]
-    (let [n0 (gen/trace :n0 (dist/uniform-discrete 1 10))
-          n1 (if (gen/trace :if-test (dist/bernoulli p))
+    (let [n0 (gen/trace :n0 dist/uniform-discrete 1 10)
+          n1 (if (gen/trace :if-test dist/bernoulli p)
                (* n0 2)
                n0)]
-      (gen/trace :fp (dist/categorical (for [i (range 1 21)]
-                                         (if (= i n1)
-                                           0.5
-                                           (/ 0.5 19))))))))
+      (gen/trace :fp dist/categorical (for [i (range 1 21)]
+                                        (if (= i n1)
+                                          0.5
+                                          (/ 0.5 19)))))))
 
-;; The `(gen/trace address (distribution args...))` expression records the value
+;; The `(gen/trace address distribution args...)` expression records the value
 ;; of the given random choice at the given address into an implicit trace data
 ;; structure. The trace data structure itself is not a variable in the function,
 ;; and that code in the body of the function cannot read from the trace. It is
@@ -334,10 +334,10 @@
 
 (def foo
   (gen [prob-a]
-    (let [a-b (or (not (gen/trace :a (dist/bernoulli prob-a)))
-                  (gen/trace :b (dist/bernoulli 0.6)))
+    (let [a-b (or (not (gen/trace :a dist/bernoulli prob-a))
+                  (gen/trace :b dist/bernoulli 0.6))
           prob-c (if a-b 0.9 0.2)]
-      (and (gen/trace :c (dist/bernoulli prob-c))
+      (and (gen/trace :c dist/bernoulli prob-c)
            a-b))))
 
 (trace/choices (gf/simulate foo [0.3]))

--- a/src/gen/clerk/viewer.cljc
+++ b/src/gen/clerk/viewer.cljc
@@ -4,7 +4,7 @@
             [nextjournal.clerk.viewer :as viewer]))
 
 (defn sleep [ms]
-  #?(:clj (Thread/sleep ms)
+  #?(:clj  (Thread/sleep ms)
      :cljs (js/setTimeout (fn []) ms)))
 
 (def delay

--- a/src/gen/dynamic.cljc
+++ b/src/gen/dynamic.cljc
@@ -1,13 +1,26 @@
 (ns gen.dynamic
-  (:require [clojure.math :as math]
-            [clojure.walk :as walk]
-            [gen]
+  (:require [clojure.walk :as walk]
             [gen.choice-map :as choice-map]
             [gen.dynamic.trace :as dynamic.trace]
             [gen.generative-function :as gf]
             [gen.trace :as trace])
   #?(:cljs
-     (:require-macros [gen.dynamic])))
+     (:require-macros [gen.dynamic :refer [untraced]])))
+
+(defn trace! [& _]
+  {:arglists '([addr f & xs])}
+  (throw
+   (ex-info "Illegal usage of `trace!` out of `gen`." {})))
+
+(defn splice! [& _]
+  {:arglists '([f & xs])}
+  (throw
+   (ex-info "Illegal usage of `splice!` out of `gen`." {})))
+
+(defmacro untraced
+  [& body]
+  `(binding [dynamic.trace/*trace* dynamic.trace/no-op]
+     ~@body))
 
 (defrecord DynamicDSLFunction [clojure-fn]
   gf/Simulate
@@ -32,7 +45,7 @@
   gf/Generate
   (generate [gf args]
     (let [trace (gf/simulate gf args)]
-      {:trace trace :weight (math/log 1)}))
+      {:trace trace :weight (Math/log 1)}))
   (generate [gf args constraints]
     (let [state (atom {:trace (dynamic.trace/trace gf args)
                        :weight 0})]
@@ -61,108 +74,135 @@
 
   #?@(:clj
       [clojure.lang.IFn
-       (invoke [_] (dynamic.trace/without-tracing (clojure-fn)))
-       (invoke [_ arg1] (dynamic.trace/without-tracing (clojure-fn arg1)))
-       (invoke [_ arg1 arg2] (dynamic.trace/without-tracing (clojure-fn arg1 arg2)))
-       (invoke [_ arg1 arg2 arg3] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3)))
-       (invoke [_ arg1 arg2 arg3 arg4] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 s] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 s)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20)))
-       (invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20 args] (apply clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20 args))
-       (applyTo [_ arglist] (dynamic.trace/without-tracing (.applyTo ^clojure.lang.IFn clojure-fn arglist)))]
+       (invoke [_]
+               (untraced (clojure-fn)))
+       (invoke [_ x1]
+               (untraced (clojure-fn x1)))
+       (invoke [_ x1 x2]
+               (untraced (clojure-fn x1 x2)))
+       (invoke [_ x1 x2 x3]
+               (untraced (clojure-fn x1 x2 x3)))
+       (invoke [_ x1 x2 x3 x4]
+               (untraced (clojure-fn x1 x2 x3 x4)))
+       (invoke [_ x1 x2 x3 x4 x5]
+               (untraced (clojure-fn x1 x2 x3 x4 x5)))
+       (invoke [_ x1 x2 x3 x4 x5 x6]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 s]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 s)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20]
+               (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20)))
+       (invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 xs]
+               (untraced
+                (apply clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 xs)))
+       (applyTo [_ xlist]
+                (untraced (.applyTo ^clojure.lang.IFn clojure-fn xlist)))]
 
       :cljs
       [IFn
-       (-invoke [_] (dynamic.trace/without-tracing (clojure-fn)))
-       (-invoke [_ arg1] (dynamic.trace/without-tracing (clojure-fn arg1)))
-       (-invoke [_ arg1 arg2] (dynamic.trace/without-tracing (clojure-fn arg1 arg2)))
-       (-invoke [_ arg1 arg2 arg3] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3)))
-       (-invoke [_ arg1 arg2 arg3 arg4] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 s] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 s)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20] (dynamic.trace/without-tracing (clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20)))
-       (-invoke [_ arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20 args] (apply clojure-fn arg1 arg2 arg3 arg4 arg5 arg6 arg7 arg8 arg9 arg10 arg11 arg12 arg13 arg14 arg15 arg16 arg17 arg18 arg19 arg20 args))]))
+       (-invoke [_]
+                (untraced (clojure-fn)))
+       (-invoke [_ x1]
+                (untraced (clojure-fn x1)))
+       (-invoke [_ x1 x2]
+                (untraced (clojure-fn x1 x2)))
+       (-invoke [_ x1 x2 x3]
+                (untraced (clojure-fn x1 x2 x3)))
+       (-invoke [_ x1 x2 x3 x4]
+                (untraced (clojure-fn x1 x2 x3 x4)))
+       (-invoke [_ x1 x2 x3 x4 x5]
+                (untraced (clojure-fn x1 x2 x3 x4 x5)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 s]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 s)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20]
+                (untraced (clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20)))
+       (-invoke [_ x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 xs]
+                (untraced (apply clojure-fn x1 x2 x3 x4 x5 x6 x7 x8 x9 x10 x11 x12 x13 x14 x15 x16 x17 x18 x19 x20 xs)))]))
 
 (defn trace-form?
   "Returns true if `form` is a trace form."
   [form]
   (and (seq? form)
-       (= `gen/trace (first form))))
+       (#{'trace! 'dynamic/trace! 'gen.dynamic/trace!} (first form))))
 
 (defn splice-form?
   "Returns true if `form` is a splice form."
   [form]
   (and (seq? form)
-       (= `gen/splice (first form))))
+       (#{'splice! 'dynamic/splice! 'gen.dynamic/splice!} (first form))))
 
-(defn valid-trace-form?
-  [form]
-  (and (trace-form? form)
-       (>= (count form) 3)
-       (let [call (last form)]
-         (and (seq? call)
-              (let [gfn (first call)]
-                (or (symbol? gfn)
-                    (and (seq gfn)
-                         (= `gen (first gfn)))))))))
+(defn ^:no-doc gen-body [& xs]
+  (let [name (when (simple-symbol? (first xs))
+               (first xs))
+        [params & body] (if name (rest xs) xs)]
+    `(->DynamicDSLFunction
+      (fn ~@(when name [name])
+        ~params
+        ~@(walk/postwalk
+           (fn [form]
+             (cond (trace-form? form)
+                   (let [[addr gf & xs] (rest form)]
+                     `((dynamic.trace/active-trace) ~addr ~gf [~@xs]))
 
-(defn valid-splice-form?
-  [form]
-  (and (splice-form? form)
-       (>= (count form) 2)
-       (let [call (last form)]
-         (and (seq? call)
-              (let [gfn (first call)]
-                (or (symbol? gfn)
-                    (and (seq gfn)
-                         (= `gen (first gfn)))))))))
+                   (splice-form? form)
+                   (let [[gf & xs] (rest form)]
+                     `((dynamic.trace/active-splice) ~gf [~@xs]))
+
+                   :else form))
+           body)))))
 
 (defmacro gen
   "Defines a generative function."
   [& args]
   {:clj-kondo/lint-as 'clojure.core/fn}
-  (let [name (when (simple-symbol? (first args))
-               (first args))
-        [params & body] (if name (rest args) args)]
-    `(->DynamicDSLFunction
-      (fn ~@(when name [name])
-        ~params
-        ~@(walk/postwalk (fn [form]
-                           (cond (trace-form? form)
-                                 (let [[addr gf & args] (rest form)]
-                                   `((dynamic.trace/active-trace) ~addr ~gf ~(vec args)))
-
-                                 (splice-form? form)
-                                 (let [[gf & args] (rest form)]
-                                   `((dynamic.trace/active-splice) ~gf ~(vec args)))
-
-                                 :else
-                                 form))
-                         body)))))
+  (apply gen-body args))

--- a/src/gen/dynamic.cljc
+++ b/src/gen/dynamic.cljc
@@ -156,16 +156,12 @@
         ~params
         ~@(walk/postwalk (fn [form]
                            (cond (trace-form? form)
-                                 (if-not (valid-trace-form? form)
-                                   (throw (ex-info "Malformed trace expression." {:form form}))
-                                   (let [[addr [gf & args]] (rest form)]
-                                     `((dynamic.trace/active-trace) ~addr ~gf ~(vec args))))
+                                 (let [[addr gf & args] (rest form)]
+                                   `((dynamic.trace/active-trace) ~addr ~gf ~(vec args)))
 
                                  (splice-form? form)
-                                 (if-not (valid-splice-form? form)
-                                   (throw (ex-info "Malformed splice expression." {:form form}))
-                                   (let [[[gf & args]] (rest form)]
-                                     `((dynamic.trace/active-splice) ~gf ~(vec args))))
+                                 (let [[gf & args] (rest form)]
+                                   `((dynamic.trace/active-splice) ~gf ~(vec args)))
 
                                  :else
                                  form))

--- a/src/gen/dynamic/trace.cljc
+++ b/src/gen/dynamic/trace.cljc
@@ -45,12 +45,6 @@
   []
   *splice*)
 
-(defmacro without-tracing
-  [& body]
-  `(binding [*trace* no-op
-             *splice* no-op]
-     ~@body))
-
 (declare assoc-subtrace update-trace trace =)
 
 (deftype Trace [gf args subtraces retval]
@@ -211,7 +205,7 @@
       (update :weight + weight)
       (cond-> discard (update :discard assoc k discard))))
 
-(defn update-trace [this constraints]
+(defn update-trace [^Trace this constraints]
   (let [gf (trace/gf this)
         state (atom {:trace (trace gf (trace/args this))
                      :weight 0

--- a/test/gen/dynamic/trace_test.cljc
+++ b/test/gen/dynamic/trace_test.cljc
@@ -2,7 +2,6 @@
   (:refer-clojure :exclude [empty? get keys seq vals])
   (:require [clojure.core :as clojure]
             [clojure.test :refer [deftest is]]
-            [gen]
             [gen.dynamic :refer [gen]]
             [gen.dynamic.choice-map :as dynamic.choice-map]
             [gen.dynamic.trace :as dynamic.trace]

--- a/test/gen/dynamic_test.cljc
+++ b/test/gen/dynamic_test.cljc
@@ -1,7 +1,6 @@
 (ns gen.dynamic-test
   (:require [clojure.math :as math]
             [clojure.test :refer [deftest is]]
-            [gen]
             [gen.distribution.kixi :as d]
             [gen.dynamic :as dynamic :refer [gen]]
             [gen.generative-function :as gf]
@@ -23,17 +22,17 @@
   (is (not (dynamic/trace-form? '(trace)))))
 
 (deftest trace-form?-true
-  (is (dynamic/trace-form? `(gen/trace)))
-  (is (dynamic/trace-form? `(gen/trace :x)))
-  (is (dynamic/trace-form? `(gen/trace ~'x)))
-  (is (dynamic/trace-form? `(gen/trace :x :y))))
+  (is (dynamic/trace-form? `(dynamic/trace!)))
+  (is (dynamic/trace-form? `(dynamic/trace! :x)))
+  (is (dynamic/trace-form? `(dynamic/trace! ~'x)))
+  (is (dynamic/trace-form? `(dynamic/trace! :x :y))))
 
 (deftest trace-args
   (is (= [0] (trace/args (gf/simulate (gen [& _]) [0]))))
   (is (= [0 1] (trace/args (gf/simulate (gen [& _]) [0 1])))))
 
 (deftest simulate-trace
-  (let [gf (gen [] (gen/trace :addr d/bernoulli))
+  (let [gf (gen [] (dynamic/trace! :addr d/bernoulli))
         trace (gf/simulate gf [])
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -42,8 +41,8 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest simulate-splice
-  (let [gf0 (gen [] (gen/trace :addr d/bernoulli))
-        gf1 (gen [] (gen/splice gf0))
+  (let [gf0 (gen [] (dynamic/trace! :addr d/bernoulli))
+        gf1 (gen [] (dynamic/splice! gf0))
         trace (gf/simulate gf1 [])
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -52,7 +51,7 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest generate-trace-trace
-  (let [gf (gen [] (gen/trace :addr d/bernoulli))
+  (let [gf (gen [] (dynamic/trace! :addr d/bernoulli))
         trace (:trace (gf/generate gf []))
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -61,8 +60,8 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest generate-splice-trace
-  (let [gf0 (gen [] (gen/trace :addr d/bernoulli))
-        gf1 (gen [] (gen/splice gf0))
+  (let [gf0 (gen [] (dynamic/trace! :addr d/bernoulli))
+        gf1 (gen [] (dynamic/splice! gf0))
         trace (:trace (gf/generate gf1 []))
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -71,15 +70,15 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest generate-call-trace
-  (let [gf0 (gen [] (gen/trace :addr d/bernoulli))
-        gf1 (gen [] (gf0))
+  (let [gf0 (gen [] (dynamic/trace! :addr d/bernoulli))
+        gf1 (gen [] (dynamic/untraced (gf0)))
         trace (:trace (gf/generate gf1 []))
         choice-map (trace/choices trace)]
     (is (empty? trace))
     (is (empty? choice-map))))
 
 (deftest generate-call-splice
-  (let [gf0 (gen [] (gen/splice d/bernoulli))
+  (let [gf0 (gen [] (d/bernoulli))
         gf1 (gen [] (gf0))
         trace (:trace (gf/generate gf1 []))
         choice-map (trace/choices trace)]
@@ -89,13 +88,13 @@
 (deftest score
   (is (= 0.5 (math/exp (trace/score (gf/simulate d/bernoulli [0.5])))))
   (let [trace (gf/simulate (gen []
-                             (gen/trace :addr d/bernoulli 0.5))
+                             (dynamic/trace! :addr d/bernoulli 0.5))
                            [])]
     (is (= 0.5 (math/exp (trace/score trace))))))
 
 (deftest update-discard-yes
   (let [gf (gen []
-             (gen/trace :discarded d/bernoulli 0))]
+             (dynamic/trace! :discarded d/bernoulli 0))]
     (is (= #gen/choice-map {:discarded false}
            (-> (gf/simulate gf [])
                (trace/update #gen/choice-map {:discarded true})
@@ -103,15 +102,15 @@
 
 (deftest update-discard-no
   (let [gf (gen []
-             (gen/trace :not-discarded d/bernoulli 0))]
+             (dynamic/trace! :not-discarded d/bernoulli 0))]
     (is (empty? (-> (gf/simulate gf [])
                     (trace/update #gen/choice-map {:discarded true})
                     (:discard))))))
 
 (deftest update-discard-both
   (let [gf (gen []
-             (gen/trace :discarded d/bernoulli 0)
-             (gen/trace :not-discarded d/bernoulli 1))]
+             (dynamic/trace! :discarded d/bernoulli 0)
+             (dynamic/trace! :not-discarded d/bernoulli 1))]
     (is (= #gen/choice-map {:discarded false}
            (-> (gf/simulate gf [])
                (trace/update #gen/choice-map {:discarded true})

--- a/test/gen/dynamic_test.cljc
+++ b/test/gen/dynamic_test.cljc
@@ -28,22 +28,12 @@
   (is (dynamic/trace-form? `(gen/trace ~'x)))
   (is (dynamic/trace-form? `(gen/trace :x :y))))
 
-(deftest valid-trace-form?-false
-  (is (not (dynamic/valid-trace-form? `(gen/trace :addr d/bernoulli))))
-  (is (not (dynamic/valid-trace-form? `(gen/trace :addr d/bernoulli [])))))
-
-(deftest valid-trace-form?-true
-  (is (dynamic/valid-trace-form? `(gen/trace :addr (d/bernoulli))))
-  (is (dynamic/valid-trace-form? `(gen/trace :addr (d/bernoulli 0.5))))
-  (is (dynamic/valid-trace-form? `(gen/trace :addr ((gen [])))))
-  (is (dynamic/valid-trace-form? `(gen/trace :addr ((gen [x]) 0)))))
-
 (deftest trace-args
   (is (= [0] (trace/args (gf/simulate (gen [& _]) [0]))))
   (is (= [0 1] (trace/args (gf/simulate (gen [& _]) [0 1])))))
 
 (deftest simulate-trace
-  (let [gf (gen [] (gen/trace :addr (d/bernoulli)))
+  (let [gf (gen [] (gen/trace :addr d/bernoulli))
         trace (gf/simulate gf [])
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -52,8 +42,8 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest simulate-splice
-  (let [gf0 (gen [] (gen/trace :addr (d/bernoulli)))
-        gf1 (gen [] (gen/splice (gf0)))
+  (let [gf0 (gen [] (gen/trace :addr d/bernoulli))
+        gf1 (gen [] (gen/splice gf0))
         trace (gf/simulate gf1 [])
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -62,7 +52,7 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest generate-trace-trace
-  (let [gf (gen [] (gen/trace :addr (d/bernoulli)))
+  (let [gf (gen [] (gen/trace :addr d/bernoulli))
         trace (:trace (gf/generate gf []))
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -71,8 +61,8 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest generate-splice-trace
-  (let [gf0 (gen [] (gen/trace :addr (d/bernoulli)))
-        gf1 (gen [] (gen/splice (gf0)))
+  (let [gf0 (gen [] (gen/trace :addr d/bernoulli))
+        gf1 (gen [] (gen/splice gf0))
         trace (:trace (gf/generate gf1 []))
         choice-map (trace/choices trace)]
     (is (= #{:addr} (set (keys trace))))
@@ -81,7 +71,7 @@
     (is (boolean? (:addr choice-map)))))
 
 (deftest generate-call-trace
-  (let [gf0 (gen [] (gen/trace :addr (d/bernoulli)))
+  (let [gf0 (gen [] (gen/trace :addr d/bernoulli))
         gf1 (gen [] (gf0))
         trace (:trace (gf/generate gf1 []))
         choice-map (trace/choices trace)]
@@ -89,7 +79,7 @@
     (is (empty? choice-map))))
 
 (deftest generate-call-splice
-  (let [gf0 (gen [] (gen/splice (d/bernoulli)))
+  (let [gf0 (gen [] (gen/splice d/bernoulli))
         gf1 (gen [] (gf0))
         trace (:trace (gf/generate gf1 []))
         choice-map (trace/choices trace)]
@@ -99,13 +89,13 @@
 (deftest score
   (is (= 0.5 (math/exp (trace/score (gf/simulate d/bernoulli [0.5])))))
   (let [trace (gf/simulate (gen []
-                             (gen/trace :addr (d/bernoulli 0.5)))
+                             (gen/trace :addr d/bernoulli 0.5))
                            [])]
     (is (= 0.5 (math/exp (trace/score trace))))))
 
 (deftest update-discard-yes
   (let [gf (gen []
-             (gen/trace :discarded (d/bernoulli 0)))]
+             (gen/trace :discarded d/bernoulli 0))]
     (is (= #gen/choice-map {:discarded false}
            (-> (gf/simulate gf [])
                (trace/update #gen/choice-map {:discarded true})
@@ -113,15 +103,15 @@
 
 (deftest update-discard-no
   (let [gf (gen []
-             (gen/trace :not-discarded (d/bernoulli 0)))]
+             (gen/trace :not-discarded d/bernoulli 0))]
     (is (empty? (-> (gf/simulate gf [])
                     (trace/update #gen/choice-map {:discarded true})
                     (:discard))))))
 
 (deftest update-discard-both
   (let [gf (gen []
-             (gen/trace :discarded (d/bernoulli 0))
-             (gen/trace :not-discarded (d/bernoulli 1)))]
+             (gen/trace :discarded d/bernoulli 0)
+             (gen/trace :not-discarded d/bernoulli 1))]
     (is (= #gen/choice-map {:discarded false}
            (-> (gf/simulate gf [])
                (trace/update #gen/choice-map {:discarded true})


### PR DESCRIPTION
This PR:

- Moves `gen.{trace,splice}` to `gen.dynamic.{trace!, splice!}` to prevent clashes between these functions and the `gen.trace` namespace
- `gen.dynamic.trace/without-tracing` becomes `gen.dynamic/untraced`
- Changes the signature of `trace` to `(trace! <addr> <gf> & <args>)`, simplifying the macro implementation and bringing it more inline with GenJAX and Gen.jl (similar change to `splice`)
- `trace!` and `splice!` called outside of a `gen` macro will now error.
- Fixes missing `untraced` call around the biggest arity of `invoke` for `DynamicDSLFunction`

There is a lurking bug that this PR exposed. `trace!` and `splice!` will currently only work if called as `trace!`, `dynamic/trace!` or `gen.dynamic/trace!`. If you bind the symbol some other way, like `d/trace!`, tracing will error.

We can fix this with some clever macro work for the cljs and SCI environments, but I want to hold off in this PR.