### PR TITLE
build: fix cljs tests, bump shadow to 2.25.8

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -23,7 +23,7 @@
 
   :cljs
   {:extra-deps
-   {thheller/shadow-cljs {:mvn/version "2.25.7"}
+   {thheller/shadow-cljs {:mvn/version "2.25.8"}
     org.clojure/clojurescript {:mvn/version "1.11.60"}}}
 
   :test

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
       },
       "devDependencies": {
         "gh-pages": "^3.2.3",
-        "shadow-cljs": "2.25.7"
+        "shadow-cljs": "2.25.8"
       }
     },
     "node_modules/@codemirror/autocomplete": {
@@ -1743,9 +1743,9 @@
       }
     },
     "node_modules/shadow-cljs": {
-      "version": "2.25.7",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.25.7.tgz",
-      "integrity": "sha512-5ZYxrabzGblKnAs4C4/L7zDRr+gBPiyxYc1oYbSzd6B31p341vBMaAWZffohSooci8txzXTpe2rVhAsLtCmiOg==",
+      "version": "2.25.8",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.25.8.tgz",
+      "integrity": "sha512-2mBn8yt1FBLrzSHDEh8NstnxTKJtn1dnKIc3CfRCGz1WczRpu1dTioWxELU78TzqQrvje4bxUgZ5wGgNSM48Pw==",
       "dev": true,
       "dependencies": {
         "node-libs-browser": "^2.2.1",
@@ -3510,9 +3510,9 @@
       }
     },
     "shadow-cljs": {
-      "version": "2.25.7",
-      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.25.7.tgz",
-      "integrity": "sha512-5ZYxrabzGblKnAs4C4/L7zDRr+gBPiyxYc1oYbSzd6B31p341vBMaAWZffohSooci8txzXTpe2rVhAsLtCmiOg==",
+      "version": "2.25.8",
+      "resolved": "https://registry.npmjs.org/shadow-cljs/-/shadow-cljs-2.25.8.tgz",
+      "integrity": "sha512-2mBn8yt1FBLrzSHDEh8NstnxTKJtn1dnKIc3CfRCGz1WczRpu1dTioWxELU78TzqQrvje4bxUgZ5wGgNSM48Pw==",
       "dev": true,
       "requires": {
         "node-libs-browser": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "devDependencies": {
     "gh-pages": "^3.2.3",
-    "shadow-cljs": "2.25.7"
+    "shadow-cljs": "2.25.8"
   },
   "scripts": {
     "test": "shadow-cljs compile test && node target/main/node-tests.js;",


### PR DESCRIPTION
This fixes the broken cljs tests, as shadow-cljs fixed https://github.com/thheller/shadow-cljs/issues/1153 in 2.25.8.