### PR TITLE
Prevent overflow in gaussian log-likelihood

### DIFF
--- a/src/gen/distribution/math/log_likelihood.cljc
+++ b/src/gen/distribution/math/log_likelihood.cljc
@@ -160,12 +160,11 @@
   \\end{aligned}
   $$"
   [mu sigma v]
-  (let [v-mu     (- v mu)
-        v-mu-sq  (* v-mu v-mu)
-        variance (* sigma sigma)]
+  (let [v-mu:sigma (/ (- v mu) sigma)]
     (* -0.5 (+ log-2pi
-               (Math/log variance)
-               (/ v-mu-sq variance)))))
+               (* 2 (Math/log sigma))
+               (* v-mu:sigma
+                  v-mu:sigma)))))
 
 (defn uniform
   "Returns the log-likelihood of the continuous [uniform

--- a/test/gen/distribution_test.cljc
+++ b/test/gen/distribution_test.cljc
@@ -174,7 +174,7 @@
                       (dist/logpdf (->normal 0.0 sigma) (- v)))
                 "Normal is symmetric about the mean")
 
-            (with-comparator (within 1e-12)
+            (with-comparator (within 1e-10)
               (is (ish? (dist/logpdf (->normal mu sigma) v)
                         (dist/logpdf (->normal (+ mu shift) sigma) (+ v shift)))
                   "shifting by the mean is a symmetry")))
@@ -182,7 +182,8 @@
   (testing "spot checks"
     (is (= -1.0439385332046727 (dist/logpdf (->normal 0 1) 0.5)))
     (is (= -1.643335713764618 (dist/logpdf (->normal 0 2) 0.5)))
-    (is (= -1.612085713764618 (dist/logpdf (->normal 0 2) 0)))))
+    (is (= -1.612085713764618 (dist/logpdf (->normal 0 2) 0)))
+    (is (= -8.996964098844152E20 (dist/logpdf (->normal 4241959036 0.1) 33978)))))
 
 (defn uniform-tests [->uniform]
   (checking "(log of the) Beta function is symmetrical"


### PR DESCRIPTION
Before this fix, our gen-finance demo was overflowing during importance sampling.